### PR TITLE
fix: render blank table cells as empty <td> elements

### DIFF
--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -372,6 +372,17 @@ describe('markdownToHtml', () => {
       expect(result).toContain('<th>');
       expect(result).toContain('<td>');
     });
+
+    it('renders blank cells as empty td elements', () => {
+      const md = '| Field | Col1 | Col2 | Col3 |\n| --- | --- | --- | --- |\n| Name |  |  |  |\n| Date | 2026-01-29 |  |  |';
+      const result = markdownToHtml(md);
+      // Row with "Name" should have 4 td elements (1 with content + 3 empty)
+      const nameRowMatch = result.match(/<tr><td><p>Name<\/p><\/td>(<td><\/td>){3}<\/tr>/);
+      expect(nameRowMatch).toBeTruthy();
+      // Row with "Date" should have 4 td elements (2 with content + 2 empty)
+      const dateRowMatch = result.match(/<tr><td><p>Date<\/p><\/td><td><p>2026-01-29<\/p><\/td>(<td><\/td>){2}<\/tr>/);
+      expect(dateRowMatch).toBeTruthy();
+    });
   });
 
   describe('blockquotes', () => {
@@ -434,5 +445,14 @@ describe('round-trip conversion', () => {
     const roundTrip = htmlToMarkdown(html);
     expect(roundTrip).toContain('- [ ] Todo');
     expect(roundTrip).toContain('- [x] Done');
+  });
+
+  it('preserves tables with blank cells', () => {
+    const original = '| Field | Col1 | Col2 |\n| --- | --- | --- |\n| Name |  |  |\n| Date | 2026-01-29 |  |';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('| Field | Col1 | Col2 |');
+    expect(roundTrip).toContain('| Name |  |  |');
+    expect(roundTrip).toContain('| Date | 2026-01-29 |  |');
   });
 });

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -548,7 +548,7 @@ export function markdownToHtml(md: string): string {
 
     let result = '<table class="editor-table">';
 
-    const headerCells = lines[0].split('|').filter(c => c.trim());
+    const headerCells = lines[0].split('|').slice(1, -1);
     result += '<thead><tr>';
     headerCells.forEach(cell => {
       result += `<th><p>${cell.trim()}</p></th>`;
@@ -558,7 +558,7 @@ export function markdownToHtml(md: string): string {
     if (lines.length > 2) {
       result += '<tbody>';
       for (let i = 2; i < lines.length; i++) {
-        const cells = lines[i].split('|').filter(c => c.trim());
+        const cells = lines[i].split('|').slice(1, -1);
         if (cells.length > 0) {
           result += '<tr>';
           cells.forEach(cell => {


### PR DESCRIPTION
## Summary

- Fix blank cells in markdown tables not rendering as `<td>` elements
- Replace `.filter(c => c.trim())` with `.slice(1, -1)` when splitting table rows by `|` — the filter was dropping empty/whitespace-only cells entirely

## Test plan

- Added unit test for tables with blank cells
- Added round-trip test verifying blank cells survive markdown → HTML → markdown conversion
- All 289 tests passing

Fixes #8