### PR TITLE
fix: wrap lines starting with inline formatting in paragraph tags

### DIFF
--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -386,6 +386,28 @@ describe('markdownToHtml', () => {
       expect(markdownToHtml('---')).toContain('<hr');
     });
   });
+
+  describe('paragraphs starting with inline formatting', () => {
+    it('wraps lines starting with bold in p tags', () => {
+      const md = '**Objective:** Provide a holistic view.';
+      const result = markdownToHtml(md);
+      expect(result).toContain('<p><strong>Objective:</strong> Provide a holistic view.</p>');
+    });
+
+    it('wraps lines starting with italic in p tags', () => {
+      const md = '*Note:* This is important.';
+      const result = markdownToHtml(md);
+      expect(result).toContain('<p><em>Note:</em> This is important.</p>');
+    });
+
+    it('preserves paragraph breaks between bold-starting lines', () => {
+      const md = 'First paragraph.\n\n**Second:** paragraph with bold start.\n\n**Third:** another bold start.';
+      const result = markdownToHtml(md);
+      expect(result).toContain('<p>First paragraph.</p>');
+      expect(result).toContain('<p><strong>Second:</strong> paragraph with bold start.</p>');
+      expect(result).toContain('<p><strong>Third:</strong> another bold start.</p>');
+    });
+  });
 });
 
 describe('round-trip conversion', () => {

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -610,8 +610,8 @@ export function markdownToHtml(md: string): string {
 
   html = parseMarkdownLists(html);
 
-  // Paragraphs
-  html = html.replace(/^(?!<[huplodtb]|<\/|<hr|<img|<a |<code|<strong|<em|<s>|__)(.+)$/gim, '<p>$1</p>');
+  // Paragraphs - exclude only block-level elements and placeholders, not inline elements
+  html = html.replace(/^(?!<[huplodtb]|<\/|<hr|<img|__)(.+)$/gim, '<p>$1</p>');
   html = html.replace(/<p>\s*<\/p>/g, '');
 
   // Restore code blocks


### PR DESCRIPTION
## Summary

- Fix paragraph breaks vanishing when switching from code view to visual mode for text starting with `**bold**`, `*italic*`, or `~~strikethrough~~`
- The paragraph regex in `markdownToHtml` was excluding inline elements (`<strong>`, `<em>`, `<s>`, `<a>`, `<code>`) from `<p>` wrapping — only block-level elements should be excluded

## Test plan

- Added unit tests for lines starting with bold/italic getting `<p>` wrapping
- Added test for paragraph breaks between bold-starting lines
- All 289 tests passing

Fixes #9