### PR TITLE
fix: add missing originalMarkdown to Tab object literals

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -62,7 +62,7 @@ const activeTabId = computed(() => activePane.value?.activeTabId || '');
 const activeTab = computed(() => {
   const tab = getActiveTabForPane(activePaneId.value);
   // Return a default tab if none exists (should never happen in practice)
-  return tab || { id: '', filePath: null, fileName: t.value.newDocument, content: '<p></p>', hasChanges: false, scrollTop: 0 };
+  return tab || { id: '', filePath: null, fileName: t.value.newDocument, content: '<p></p>', hasChanges: false, scrollTop: 0, originalMarkdown: null };
 });
 
 // ============ Editor References ============

--- a/src/__tests__/composables/useCloseConfirmation.test.ts
+++ b/src/__tests__/composables/useCloseConfirmation.test.ts
@@ -35,6 +35,7 @@ describe('useCloseConfirmation', () => {
     content: '<p>Test content</p>',
     hasChanges: false,
     scrollTop: 0,
+    originalMarkdown: null,
     ...overrides,
   });
 

--- a/src/composables/useSplitView.ts
+++ b/src/composables/useSplitView.ts
@@ -181,6 +181,7 @@ export function useSplitView(): UseSplitViewReturn {
       content,
       hasChanges: false,
       scrollTop: 0,
+      originalMarkdown: null,
     };
 
     pane.tabs.push(newTab);


### PR DESCRIPTION
## Summary
- Fixes TypeScript build errors introduced in #14 where `originalMarkdown` was added to the `Tab` interface but not to all object literals creating `Tab` instances
- Adds `originalMarkdown: null` to fallback tab in `App.vue`, `useSplitView.ts`, and test mock in `useCloseConfirmation.test.ts`

## Test plan
- [x] `vue-tsc --noEmit` passes with no errors
- [x] All 323 tests pass
- [x] CI build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)