### PR TITLE
feat: add editor zoom with Ctrl+Scroll and toolbar controls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,7 @@ import { useFileOperations } from './composables/useFileOperations';
 import { useCloseConfirmation } from './composables/useCloseConfirmation';
 import { useWindowManager } from './composables/useWindowManager';
 import { useTabDrag } from './composables/useTabDrag';
+import { useEditorZoom } from './composables/useEditorZoom';
 import { t } from './i18n';
 
 // ============ Split View & Tab Management ============
@@ -390,6 +391,20 @@ const {
 // ============ Settings ============
 const { settings } = useSettings();
 
+// ============ Editor Zoom ============
+const { zoomIn, zoomOut } = useEditorZoom();
+
+const handleWheel = (event: WheelEvent) => {
+  if (event.ctrlKey || event.metaKey) {
+    event.preventDefault();
+    if (event.deltaY < 0) {
+      zoomIn();
+    } else {
+      zoomOut();
+    }
+  }
+};
+
 // ============ Sync Active Tab Content ============
 // This ensures that the active tab's content and hasChanges are up to date
 // before checking for unsaved changes (e.g., when closing the window)
@@ -609,6 +624,7 @@ const openFileWithCrossWindowDialog = async (): Promise<void> => {
 
 onMounted(async () => {
   window.addEventListener('keydown', handleKeyboard);
+  window.addEventListener('wheel', handleWheel, { passive: false });
 
   // Get current window label for file registry
   try {
@@ -703,6 +719,7 @@ onMounted(async () => {
 
 onUnmounted(async () => {
   window.removeEventListener('keydown', handleKeyboard);
+  window.removeEventListener('wheel', handleWheel);
   if (unlistenOpenFile) {
     unlistenOpenFile();
   }

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { useEditorZoom } from '../composables/useEditorZoom';
+
+const { zoomScale } = useEditorZoom();
+const codeZoomStyle = computed(() => ({ zoom: zoomScale.value }));
 
 defineProps<{
   modelValue: string;
@@ -28,6 +32,7 @@ const handleInput = (event: Event) => {
       id="code-editor-textarea"
       ref="textareaRef"
       class="code-editor"
+      :style="codeZoomStyle"
       :value="modelValue"
       @input="handleInput"
       spellcheck="false"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -18,8 +18,9 @@ import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import { common, createLowlight } from "lowlight";
-import { watch, ref, nextTick } from "vue";
+import { watch, ref, nextTick, computed } from "vue";
 import { Extension, Node, mergeAttributes, textblockTypeInputRule } from "@tiptap/core";
+import { useEditorZoom } from "../composables/useEditorZoom";
 import TableContextMenu from "./TableContextMenu.vue";
 
 // Guards against false hasChanges during programmatic content updates.
@@ -120,6 +121,8 @@ const HeadingWithId = Node.create({
 });
 
 const editorContainerRef = ref<HTMLDivElement | null>(null);
+const { zoomScale } = useEditorZoom();
+const editorZoomStyle = computed(() => ({ zoom: zoomScale.value }));
 
 // Table context menu state
 const showContextMenu = ref(false);
@@ -430,7 +433,7 @@ defineExpose({ editor });
 
 <template>
   <div class="editor-container" ref="editorContainerRef" @click="handleEditorClick" @contextmenu="handleContextMenu">
-    <EditorContent :editor="editor" class="editor-content" />
+    <EditorContent :editor="editor" class="editor-content" :style="editorZoomStyle" />
     <TableContextMenu
       v-if="showContextMenu"
       :x="contextMenuX"

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -4,10 +4,12 @@ import type { Editor } from "@tiptap/vue-3";
 import { useI18n } from "../i18n";
 import { useSettings } from "../composables/useSettings";
 import { useTokenCounter } from "../composables/useTokenCounter";
+import { useEditorZoom } from "../composables/useEditorZoom";
 import { htmlToMarkdown } from "../utils/markdown-converter";
 
 const { t, locale, toggleLocale } = useI18n();
 const { settings, toggleAutoSave, toggleTheme } = useSettings();
+const { zoomPercent, zoomIn, zoomOut, resetZoom } = useEditorZoom();
 const {
   tokenCount,
   modelName,
@@ -572,6 +574,30 @@ const emit = defineEmits<{
 
       <div class="toolbar-separator"></div>
 
+      <!-- Editor Zoom -->
+      <div class="toolbar-group zoom-group">
+        <button @click="zoomOut" class="toolbar-btn icon-only" :title="t.zoomOut">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            <line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+        </button>
+        <button @click="resetZoom" class="toolbar-btn zoom-percent-btn" :title="t.reset">
+          {{ zoomPercent }}%
+        </button>
+        <button @click="zoomIn" class="toolbar-btn icon-only" :title="t.zoomIn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="11" cy="11" r="8"/>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+            <line x1="11" y1="8" x2="11" y2="14"/>
+            <line x1="8" y1="11" x2="14" y2="11"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="toolbar-separator"></div>
+
       <!-- Code View Toggle -->
       <button
         @click="emit('toggleCodeView')"
@@ -1127,5 +1153,19 @@ const emit = defineEmits<{
 .token-menu .dropdown-item.active {
   background: var(--token-active-bg);
   color: var(--token-active-color);
+}
+
+/* Editor Zoom */
+.zoom-group {
+  gap: 0;
+}
+
+.zoom-percent-btn {
+  font-size: 12px;
+  font-weight: 500;
+  min-width: 44px;
+  padding: 4px 6px;
+  justify-content: center;
+  color: var(--text-muted);
 }
 </style>

--- a/src/composables/useEditorZoom.ts
+++ b/src/composables/useEditorZoom.ts
@@ -1,0 +1,54 @@
+import { ref, computed, watch } from 'vue';
+
+const STORAGE_KEY = 'mermark-editor-zoom';
+const MIN_ZOOM = 50;
+const MAX_ZOOM = 200;
+const ZOOM_STEP = 10;
+const DEFAULT_ZOOM = 100;
+
+function loadZoom(): number {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const value = parseInt(saved, 10);
+      if (value >= MIN_ZOOM && value <= MAX_ZOOM) return value;
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_ZOOM;
+}
+
+const zoomPercent = ref(loadZoom());
+
+watch(zoomPercent, (value) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(value));
+  } catch {
+    // ignore
+  }
+});
+
+export function useEditorZoom() {
+  const zoomScale = computed(() => zoomPercent.value / 100);
+
+  const zoomIn = () => {
+    zoomPercent.value = Math.min(MAX_ZOOM, zoomPercent.value + ZOOM_STEP);
+  };
+
+  const zoomOut = () => {
+    zoomPercent.value = Math.max(MIN_ZOOM, zoomPercent.value - ZOOM_STEP);
+  };
+
+  const resetZoom = () => {
+    zoomPercent.value = DEFAULT_ZOOM;
+  };
+
+  return {
+    zoomPercent,
+    zoomScale,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+  };
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -165,6 +165,9 @@ export interface Translations {
   confirmNavigateTo: string;
   openLink: string;
 
+  // Editor Zoom
+  zoom: string;
+
   // Theme
   darkMode: string;
   lightMode: string;
@@ -333,6 +336,9 @@ const translations: Record<Locale, Translations> = {
     confirmNavigateTo: 'Are you sure you want to navigate to:',
     openLink: 'Open',
 
+    // Editor Zoom
+    zoom: 'Zoom',
+
     // Theme
     darkMode: 'Dark',
     lightMode: 'Light',
@@ -499,6 +505,9 @@ const translations: Record<Locale, Translations> = {
     openExternalLink: 'Otwórz link zewnętrzny',
     confirmNavigateTo: 'Czy na pewno chcesz przejść do:',
     openLink: 'Otwórz',
+
+    // Editor Zoom
+    zoom: 'Powiększenie',
 
     // Theme
     darkMode: 'Ciemny',


### PR DESCRIPTION
Zoom the WYSIWYG editor and code editor views from 50% to 200% in 10% increments. Zoom level persists across sessions via localStorage. Toolbar displays zoom-out, percentage/reset, and zoom-in buttons.

Ctrl-Scroll works for shortcut.

Looked like you were heading this way in any case, simple add.