### PR TITLE
fix: hide left bar, status bar and split divider in print/PDF output

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -506,6 +506,9 @@ button:disabled {
   /* Hide app UI - including tab bar and dialogs */
   .toolbar,
   .tab-bar,
+  .left-bar,
+  .status-bar,
+  .split-divider,
   .app > header,
   .mermaid-header,
   .mermaid-actions,


### PR DESCRIPTION
## Summary
- Hide `.left-bar`, `.status-bar` and `.split-divider` in `@media print` rules
- Fixes toolbar icons appearing on exported PDF when user has panels configured