### PR TITLE
fix: trailing blank lines on all save paths, resizable mermaid editor split (#53, #51)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -577,7 +577,7 @@ const saveTabFromPane = async (paneId: string, tabId: string) => {
     // For active tab in active pane, get fresh content from editor; for others, use stored content
     const isActiveTab = tabId === activeTabId.value && paneId === activePaneId.value;
     const html = isActiveTab ? getEditorContent() : tab.content;
-    let markdown = htmlToMarkdown(html);
+    let markdown = htmlToMarkdown(html).trimEnd();
 
     // Preserve original line endings
     if (tab.originalMarkdown) {

--- a/src/components/MermaidNode.vue
+++ b/src/components/MermaidNode.vue
@@ -26,7 +26,7 @@ const props = defineProps<{
 const sizeOptions = [25, 50, 75, 100] as const;
 
 // Current diagram size
-const diagramSize = computed(() => props.node.attrs.printScale || 100);
+const diagramSize = computed(() => props.node.attrs.printScale || 25);
 
 const setDiagramSize = (size: number) => {
   props.updateAttributes({ printScale: size });
@@ -77,6 +77,38 @@ const {
 
 const handlePreviewFitToView = () => {
   previewFitToView(previewContainerRef.value, previewViewportRef.value);
+};
+
+// Resizable split between code and preview panes
+const splitRatio = ref(50);
+let isDraggingSplit = false;
+let splitContainerRect: DOMRect | null = null;
+
+const splitContainerEl = ref<HTMLElement | null>(null);
+
+const startSplitDrag = (e: MouseEvent) => {
+  isDraggingSplit = true;
+  const container = (e.target as HTMLElement).closest('.editor-split-fullscreen') as HTMLElement;
+  splitContainerEl.value = container;
+  if (container) splitContainerRect = container.getBoundingClientRect();
+  document.addEventListener('mousemove', doSplitDrag);
+  document.addEventListener('mouseup', endSplitDrag);
+  e.preventDefault();
+};
+
+const doSplitDrag = (e: MouseEvent) => {
+  if (!isDraggingSplit || !splitContainerEl.value) return;
+  splitContainerRect = splitContainerEl.value.getBoundingClientRect();
+  const x = e.clientX - splitContainerRect.left;
+  const pct = (x / splitContainerRect.width) * 100;
+  splitRatio.value = Math.min(80, Math.max(20, pct));
+};
+
+const endSplitDrag = () => {
+  isDraggingSplit = false;
+  splitContainerRect = null;
+  document.removeEventListener('mousemove', doSplitDrag);
+  document.removeEventListener('mouseup', endSplitDrag);
 };
 
 const renderPreview = async () => {
@@ -317,7 +349,7 @@ watch(editCode, () => {
         </div>
         <!-- Split: code left, preview right -->
         <div class="editor-split-fullscreen">
-          <div class="editor-code-pane">
+          <div class="editor-code-pane" :style="{ flex: `0 0 ${splitRatio}%` }">
             <textarea
               id="mermaid-editor-textarea"
               v-model="editCode"
@@ -326,7 +358,10 @@ watch(editCode, () => {
               @keydown="handleTextareaKeydown"
             ></textarea>
           </div>
-          <div class="editor-preview-pane">
+          <div class="split-divider-mermaid" @mousedown="startSplitDrag">
+            <div class="divider-handle-mermaid"></div>
+          </div>
+          <div class="editor-preview-pane" :style="{ flex: `0 0 ${100 - splitRatio}%` }">
             <div class="editor-preview-toolbar">
               <button @click="previewZoomOut" class="btn-zoom" title="Zoom out">−</button>
               <span class="zoom-level">{{ previewZoomPercent }}%</span>
@@ -607,10 +642,8 @@ watch(editCode, () => {
 }
 
 .editor-code-pane {
-  flex: 1;
   display: flex;
   min-width: 0;
-  border-right: 1px solid var(--border-primary);
 }
 
 .editor-code-pane .mermaid-textarea {
@@ -624,8 +657,45 @@ watch(editCode, () => {
   line-height: 1.6;
 }
 
+.split-divider-mermaid {
+  width: 8px;
+  cursor: col-resize;
+  background: var(--divider-bg, #e2e8f0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.split-divider-mermaid::before {
+  content: '';
+  position: absolute;
+  left: -6px;
+  right: -6px;
+  top: 0;
+  bottom: 0;
+  cursor: col-resize;
+}
+
+.split-divider-mermaid:hover,
+.split-divider-mermaid:active {
+  background: var(--divider-hover, #cbd5e1);
+}
+
+.divider-handle-mermaid {
+  width: 2px;
+  height: 32px;
+  border-radius: 1px;
+  background: var(--divider-handle, #94a3b8);
+}
+
+.split-divider-mermaid:hover .divider-handle-mermaid,
+.split-divider-mermaid:active .divider-handle-mermaid {
+  background: var(--divider-handle-hover, #64748b);
+}
+
 .editor-preview-pane {
-  flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;

--- a/src/components/SplitContainer.vue
+++ b/src/components/SplitContainer.vue
@@ -72,7 +72,7 @@ onMounted(() => {
 
       // Save file content before transfer
       if (tab && tab.content) {
-        const markdownContent = htmlToMarkdown(tab.content);
+        const markdownContent = htmlToMarkdown(tab.content).trimEnd();
         await writeTextFile(filePath, markdownContent);
       }
 

--- a/src/composables/useCloseConfirmation.ts
+++ b/src/composables/useCloseConfirmation.ts
@@ -86,7 +86,7 @@ export function useCloseConfirmation(options: UseCloseConfirmationOptions): UseC
       if (filePath) {
         // Get current content - if this is the active tab, get from editor
         const html = tab.id === activeTabId.value ? getEditorHtml() : tab.content;
-        const markdown = htmlToMarkdown(html);
+        const markdown = htmlToMarkdown(html).trimEnd();
         await writeTextFile(filePath, markdown);
 
         // Update the tab

--- a/src/composables/useFileOperations.ts
+++ b/src/composables/useFileOperations.ts
@@ -189,6 +189,8 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
       markdown = applyLineEnding(markdown, originalLineEnding);
     }
 
+    markdown = markdown.trimEnd();
+
     // Pre-save conflict check
     let mergedContentApplied = false;
     if (tabIndex !== -1 && onPreSaveConflict) {

--- a/src/extensions/MermaidExtension.ts
+++ b/src/extensions/MermaidExtension.ts
@@ -50,14 +50,14 @@ export const MermaidExtension = Node.create<MermaidOptions>({
         },
       },
       printScale: {
-        default: 100,
+        default: 25,
         parseHTML: (element) => {
           const scale = element.getAttribute("data-print-scale");
-          return scale ? parseInt(scale, 10) : 100;
+          return scale ? parseInt(scale, 10) : 25;
         },
         renderHTML: (attributes) => {
           return {
-            "data-print-scale": attributes.printScale || 100,
+            "data-print-scale": attributes.printScale || 25,
           };
         },
       },


### PR DESCRIPTION
## Summary

- **Trailing blank lines (#53):** Added `.trimEnd()` to three save paths that were missing it (close-confirmation, split-pane transfer, auto-save) and a final `.trimEnd()` after `applyLineEnding` as a safety net
- **Resizable mermaid editor (#51):** Added a draggable divider between code and preview panes in the fullscreen mermaid editor, with a 20px hit area for easy grabbing and live rect recalculation to prevent jitter on window resize
- **Mermaid default scale:** Changed from 100% to 25% for new diagrams

## Test plan

- [x] Open markdown file, edit, save → verify no trailing blank lines in external editor
- [x] Toggle code view, save, toggle back, save → no trailing blank lines
- [x] Close tab with unsaved changes → save from close dialog → no trailing blank lines
- [x] Open mermaid diagram → click Edit → drag divider between code/preview panes
- [x] Resize app window while dragging divider → no jitter
- [x] New mermaid diagram renders at 25% scale by default