### PR TITLE
feat: footnotes support + update dialog improvements (closes #60)

### DIFF
--- a/src/__tests__/components/FootnoteNode.test.ts
+++ b/src/__tests__/components/FootnoteNode.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FootnoteNode from '../../components/FootnoteNode.vue';
+
+// Stub the NodeViewWrapper from @tiptap/vue-3 so we can mount the component
+// without a full ProseMirror/Tiptap environment.
+vi.mock('@tiptap/vue-3', () => ({
+  NodeViewWrapper: {
+    name: 'NodeViewWrapper',
+    template: '<section><slot /></section>',
+  },
+}));
+
+function makeProps(definitions: Array<{ label: string; content: string }>) {
+  return {
+    node: { attrs: { definitions: JSON.stringify(definitions) } },
+    updateAttributes: vi.fn(),
+    selected: false,
+  };
+}
+
+describe('FootnoteNode', () => {
+  it('mounts without template compile errors', () => {
+    const wrapper = mount(FootnoteNode, { props: makeProps([]) });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders each definition with index and content', () => {
+    const wrapper = mount(FootnoteNode, {
+      props: makeProps([
+        { label: '1', content: 'First note' },
+        { label: 'note', content: 'Named note' },
+      ]),
+    });
+    const items = wrapper.findAll('.footnote-item');
+    expect(items).toHaveLength(2);
+    expect(items[0].text()).toContain('1.');
+    expect(items[0].text()).toContain('First note');
+    expect(items[1].text()).toContain('2.');
+    expect(items[1].text()).toContain('Named note');
+  });
+
+  it('exposes the definition label on data-footnote-label', () => {
+    const wrapper = mount(FootnoteNode, {
+      props: makeProps([{ label: 'foo', content: 'bar' }]),
+    });
+    expect(wrapper.find('[data-footnote-label="foo"]').exists()).toBe(true);
+  });
+
+  it('renders backlink button for each definition', () => {
+    const wrapper = mount(FootnoteNode, {
+      props: makeProps([
+        { label: '1', content: 'a' },
+        { label: '2', content: 'b' },
+      ]),
+    });
+    expect(wrapper.findAll('.footnote-backlink')).toHaveLength(2);
+  });
+
+  it('backlink click dispatches mermark-footnote-backlink event with label', async () => {
+    const wrapper = mount(FootnoteNode, {
+      props: makeProps([{ label: 'my-label', content: 'x' }]),
+      attachTo: document.body,
+    });
+
+    let capturedLabel: string | null = null;
+    document.body.addEventListener(
+      'mermark-footnote-backlink',
+      (e) => { capturedLabel = (e as CustomEvent<{ label: string }>).detail.label; },
+      { once: true },
+    );
+
+    await wrapper.find('.footnote-backlink').trigger('click');
+    expect(capturedLabel).toBe('my-label');
+    wrapper.unmount();
+  });
+
+  it('handles malformed definitions JSON gracefully', () => {
+    const wrapper = mount(FootnoteNode, {
+      props: {
+        node: { attrs: { definitions: 'not-json' } },
+        updateAttributes: vi.fn(),
+        selected: false,
+      },
+    });
+    expect(wrapper.findAll('.footnote-item')).toHaveLength(0);
+  });
+
+  it('enters edit mode when clicking definition content', async () => {
+    const wrapper = mount(FootnoteNode, {
+      props: makeProps([{ label: '1', content: 'original' }]),
+    });
+    await wrapper.find('.footnote-def-content').trigger('click');
+    expect(wrapper.find('.footnote-edit-input').exists()).toBe(true);
+  });
+
+  it('calls updateAttributes with new content on blur save', async () => {
+    const updateAttributes = vi.fn();
+    const wrapper = mount(FootnoteNode, {
+      props: {
+        node: { attrs: { definitions: JSON.stringify([{ label: '1', content: 'old' }]) } },
+        updateAttributes,
+        selected: false,
+      },
+    });
+
+    await wrapper.find('.footnote-def-content').trigger('click');
+    const textarea = wrapper.find<HTMLTextAreaElement>('.footnote-edit-input');
+    await textarea.setValue('updated');
+    await textarea.trigger('blur');
+
+    expect(updateAttributes).toHaveBeenCalledWith({
+      definitions: JSON.stringify([{ label: '1', content: 'updated' }]),
+    });
+  });
+
+  it('cancels edit on Escape without calling updateAttributes', async () => {
+    const updateAttributes = vi.fn();
+    const wrapper = mount(FootnoteNode, {
+      props: {
+        node: { attrs: { definitions: JSON.stringify([{ label: '1', content: 'old' }]) } },
+        updateAttributes,
+        selected: false,
+      },
+    });
+
+    await wrapper.find('.footnote-def-content').trigger('click');
+    const textarea = wrapper.find<HTMLTextAreaElement>('.footnote-edit-input');
+    await textarea.setValue('updated');
+    await textarea.trigger('keydown', { key: 'Escape' });
+
+    expect(updateAttributes).not.toHaveBeenCalled();
+    expect(wrapper.find('.footnote-edit-input').exists()).toBe(false);
+  });
+});

--- a/src/__tests__/components/UpdateDialog.test.ts
+++ b/src/__tests__/components/UpdateDialog.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import UpdateDialog from '../../components/UpdateDialog.vue';
+
+describe('UpdateDialog', () => {
+  it('mounts without template compile errors', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '' },
+    });
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it('renders the version string', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '' },
+    });
+    expect(wrapper.text()).toContain('0.1.72');
+  });
+
+  it('renders notes when provided', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '## New features\n\n- Footnote support' },
+    });
+    expect(wrapper.find('.update-notes').exists()).toBe(true);
+    expect(wrapper.html()).toContain('New features');
+  });
+
+  it('hides notes section when notes are empty', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '' },
+    });
+    expect(wrapper.find('.update-notes-container').exists()).toBe(false);
+  });
+
+  it('toggles notes expanded state on button click', async () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '- change one' },
+    });
+    const toggle = wrapper.find('.update-notes-toggle');
+    expect(toggle.exists()).toBe(true);
+    expect(toggle.classes()).toContain('expanded');
+
+    await toggle.trigger('click');
+    expect(toggle.classes()).not.toContain('expanded');
+
+    await toggle.trigger('click');
+    expect(toggle.classes()).toContain('expanded');
+  });
+
+  it('emits close on Later button', async () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '' },
+    });
+    await wrapper.find('.btn-cancel').trigger('click');
+    expect(wrapper.emitted('close')).toBeTruthy();
+  });
+
+  it('emits update on Update Now button', async () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '' },
+    });
+    await wrapper.find('.btn-confirm').trigger('click');
+    expect(wrapper.emitted('update')).toBeTruthy();
+  });
+
+  it('disables buttons while updating', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '', isUpdating: true },
+    });
+    expect(wrapper.find<HTMLButtonElement>('.btn-cancel').element.disabled).toBe(true);
+    expect(wrapper.find<HTMLButtonElement>('.btn-confirm').element.disabled).toBe(true);
+  });
+
+  it('shows progress bar during update', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '', isUpdating: true, progress: 42 },
+    });
+    const fill = wrapper.find<HTMLDivElement>('.progress-fill');
+    expect(fill.exists()).toBe(true);
+    expect(fill.element.style.width).toBe('42%');
+  });
+
+  it('shows error message when provided', () => {
+    const wrapper = mount(UpdateDialog, {
+      props: { version: '0.1.72', notes: '', error: 'Network failed' },
+    });
+    expect(wrapper.find('.update-error').text()).toBe('Network failed');
+  });
+});

--- a/src/__tests__/composables/useAutoUpdate.test.ts
+++ b/src/__tests__/composables/useAutoUpdate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { useAutoUpdate } from '../../composables/useAutoUpdate';
+
+const DISMISSED_KEY = 'mermark-dismissed-update-version';
+
+// Hoisted mock state for @tauri-apps/plugin-updater
+const mockCheckResult = vi.hoisted(() => ({ value: null as { version: string; body: string } | null }));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({
+  check: vi.fn(async () => mockCheckResult.value),
+}));
+
+describe('useAutoUpdate', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockCheckResult.value = null;
+    // Prevent real network calls via fetch
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does nothing when no update is available', async () => {
+    mockCheckResult.value = null;
+    const { checkForUpdates, showUpdateDialog, updateInfo } = useAutoUpdate();
+
+    await checkForUpdates();
+    expect(showUpdateDialog.value).toBe(false);
+    expect(updateInfo.value).toBeNull();
+  });
+
+  it('shows dialog when an update is available', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: 'Release notes here' };
+    const { checkForUpdates, showUpdateDialog, updateInfo } = useAutoUpdate();
+
+    await checkForUpdates();
+    expect(showUpdateDialog.value).toBe(true);
+    expect(updateInfo.value).toEqual({ version: '0.1.72', notes: 'Release notes here' });
+  });
+
+  it('skips dialog when version was previously dismissed', async () => {
+    localStorage.setItem(DISMISSED_KEY, '0.1.72');
+    mockCheckResult.value = { version: '0.1.72', body: 'notes' };
+    const { checkForUpdates, showUpdateDialog } = useAutoUpdate();
+
+    await checkForUpdates();
+    expect(showUpdateDialog.value).toBe(false);
+  });
+
+  it('still shows dialog for a NEW version even if older was dismissed', async () => {
+    localStorage.setItem(DISMISSED_KEY, '0.1.71');
+    mockCheckResult.value = { version: '0.1.72', body: 'new notes' };
+    const { checkForUpdates, showUpdateDialog } = useAutoUpdate();
+
+    await checkForUpdates();
+    expect(showUpdateDialog.value).toBe(true);
+  });
+
+  it('persists dismissed version when closeUpdateDialog is called', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: 'notes' };
+    const { checkForUpdates, closeUpdateDialog, showUpdateDialog } = useAutoUpdate();
+
+    await checkForUpdates();
+    closeUpdateDialog();
+
+    expect(showUpdateDialog.value).toBe(false);
+    expect(localStorage.getItem(DISMISSED_KEY)).toBe('0.1.72');
+  });
+
+  it('does not dismiss while update is in progress', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: 'notes' };
+    const { checkForUpdates, closeUpdateDialog, isUpdating, showUpdateDialog } = useAutoUpdate();
+
+    await checkForUpdates();
+    isUpdating.value = true;
+    closeUpdateDialog();
+
+    // Still open, nothing persisted
+    expect(showUpdateDialog.value).toBe(true);
+    expect(localStorage.getItem(DISMISSED_KEY)).toBeNull();
+  });
+
+  it('falls back to GitHub API when Tauri body is empty', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: '' };
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ body: 'From GitHub API' }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { checkForUpdates, updateInfo } = useAutoUpdate();
+    await checkForUpdates();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com/repos/Vesperino/MerMarkEditor/releases/tags/v0.1.72'),
+    );
+    expect(updateInfo.value?.notes).toBe('From GitHub API');
+  });
+
+  it('does not call GitHub API when Tauri body is non-empty', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: 'Tauri provided' };
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { checkForUpdates, updateInfo } = useAutoUpdate();
+    await checkForUpdates();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(updateInfo.value?.notes).toBe('Tauri provided');
+  });
+
+  it('handles GitHub API failure silently (empty notes)', async () => {
+    mockCheckResult.value = { version: '0.1.72', body: '' };
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network'); }));
+
+    const { checkForUpdates, updateInfo } = useAutoUpdate();
+    await checkForUpdates();
+
+    expect(updateInfo.value?.notes).toBe('');
+  });
+});

--- a/src/__tests__/utils/footnote-utils.test.ts
+++ b/src/__tests__/utils/footnote-utils.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractFootnoteDefinitions,
+  convertFootnoteRefsToHtml,
+  buildFootnoteSectionHtml,
+  convertHtmlFootnoteRefsToMd,
+  extractHtmlFootnoteSection,
+} from '../../utils/footnote-utils';
+
+describe('extractFootnoteDefinitions', () => {
+  it('extracts a single-line definition', () => {
+    const md = 'Text[^1]\n\n[^1]: Footnote text.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toEqual([{ label: '1', content: 'Footnote text.' }]);
+    expect(cleanedMd).toBe('Text[^1]\n');
+  });
+
+  it('extracts multiple definitions', () => {
+    const md = 'Text[^1] and [^2].\n\n[^1]: First.\n[^2]: Second.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(2);
+    expect(definitions[0]).toEqual({ label: '1', content: 'First.' });
+    expect(definitions[1]).toEqual({ label: '2', content: 'Second.' });
+    expect(cleanedMd).toBe('Text[^1] and [^2].\n');
+  });
+
+  it('extracts definitions with named labels', () => {
+    const md = 'Text[^note].\n\n[^note]: A named footnote.';
+    const { definitions } = extractFootnoteDefinitions(md);
+    expect(definitions[0].label).toBe('note');
+    expect(definitions[0].content).toBe('A named footnote.');
+  });
+
+  it('handles multi-line definitions with 4-space continuation', () => {
+    const md = '[^1]: First line\n    continuation line\n    another line';
+    const { definitions } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(1);
+    expect(definitions[0].content).toBe('First line\ncontinuation line\nanother line');
+  });
+
+  it('handles multi-paragraph definitions (blank line + indented continuation)', () => {
+    const md = '[^1]: First paragraph.\n\n    Second paragraph.';
+    const { definitions } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(1);
+    expect(definitions[0].content).toBe('First paragraph.\n\nSecond paragraph.');
+  });
+
+  it('terminates definition at blank line not followed by indented content', () => {
+    const md = '[^1]: Footnote.\n\nRegular paragraph.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(1);
+    expect(definitions[0].content).toBe('Footnote.');
+    expect(cleanedMd).toContain('Regular paragraph.');
+  });
+
+  it('handles definitions scattered in the document', () => {
+    const md = 'Intro[^1].\n\n[^1]: First footnote.\n\nMiddle[^2].\n\n[^2]: Second footnote.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(2);
+    expect(cleanedMd).toContain('Intro[^1].');
+    expect(cleanedMd).toContain('Middle[^2].');
+    expect(cleanedMd).not.toContain('[^1]:');
+    expect(cleanedMd).not.toContain('[^2]:');
+  });
+
+  it('returns empty definitions when none exist', () => {
+    const md = 'No footnotes here.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(0);
+    expect(cleanedMd).toBe(md);
+  });
+
+  it('does not match definitions inside content (non-start-of-line)', () => {
+    const md = 'Text with [^1]: not a definition.';
+    const { definitions, cleanedMd } = extractFootnoteDefinitions(md);
+    expect(definitions).toHaveLength(0);
+    expect(cleanedMd).toBe(md);
+  });
+});
+
+describe('convertFootnoteRefsToHtml', () => {
+  const defs = [
+    { label: '1', content: 'First' },
+    { label: 'note', content: 'Named' },
+  ];
+
+  it('converts [^1] to <sup>', () => {
+    const result = convertFootnoteRefsToHtml('Text [^1] here.', defs);
+    expect(result).toBe('Text <sup class="footnote-ref" data-footnote-ref="1">1</sup> here.');
+  });
+
+  it('converts named refs', () => {
+    const result = convertFootnoteRefsToHtml('Text [^note].', defs);
+    expect(result).toContain('data-footnote-ref="note"');
+    expect(result).toContain('>2</sup>');
+  });
+
+  it('leaves unknown refs unchanged', () => {
+    const result = convertFootnoteRefsToHtml('Text [^unknown].', defs);
+    expect(result).toBe('Text [^unknown].');
+  });
+
+  it('skips refs inside <code> tags', () => {
+    const result = convertFootnoteRefsToHtml('<code>[^1]</code> and [^1]', defs);
+    expect(result).toBe('<code>[^1]</code> and <sup class="footnote-ref" data-footnote-ref="1">1</sup>');
+  });
+
+  it('converts multiple refs in one line', () => {
+    const result = convertFootnoteRefsToHtml('[^1] and [^note]', defs);
+    expect(result).toContain('data-footnote-ref="1">1</sup>');
+    expect(result).toContain('data-footnote-ref="note">2</sup>');
+  });
+});
+
+describe('buildFootnoteSectionHtml', () => {
+  it('returns empty string for no definitions', () => {
+    expect(buildFootnoteSectionHtml([])).toBe('');
+  });
+
+  it('builds section with single definition', () => {
+    const html = buildFootnoteSectionHtml([{ label: '1', content: 'Footnote text.' }]);
+    expect(html).toContain('<section class="footnotes" data-footnotes>');
+    expect(html).toContain('<hr>');
+    expect(html).toContain('<ol>');
+    expect(html).toContain('<li data-footnote-id="1"><p>Footnote text.</p></li>');
+    expect(html).toContain('</ol></section>');
+  });
+
+  it('escapes HTML in definition content', () => {
+    const html = buildFootnoteSectionHtml([{ label: '1', content: 'Use <div> tag.' }]);
+    expect(html).toContain('&lt;div&gt;');
+  });
+
+  it('builds section with multiple definitions', () => {
+    const defs = [
+      { label: '1', content: 'First.' },
+      { label: '2', content: 'Second.' },
+    ];
+    const html = buildFootnoteSectionHtml(defs);
+    expect(html).toContain('data-footnote-id="1"');
+    expect(html).toContain('data-footnote-id="2"');
+  });
+});
+
+describe('convertHtmlFootnoteRefsToMd', () => {
+  it('converts <sup> to [^label]', () => {
+    const html = 'Text <sup class="footnote-ref" data-footnote-ref="1">1</sup> here.';
+    expect(convertHtmlFootnoteRefsToMd(html)).toBe('Text [^1] here.');
+  });
+
+  it('handles multiple refs', () => {
+    const html = '<sup class="footnote-ref" data-footnote-ref="1">1</sup> and <sup class="footnote-ref" data-footnote-ref="note">2</sup>';
+    const result = convertHtmlFootnoteRefsToMd(html);
+    expect(result).toBe('[^1] and [^note]');
+  });
+
+  it('leaves non-footnote <sup> tags unchanged', () => {
+    const html = '<sup>2</sup>';
+    expect(convertHtmlFootnoteRefsToMd(html)).toBe('<sup>2</sup>');
+  });
+});
+
+describe('extractHtmlFootnoteSection', () => {
+  it('returns unchanged html when no section exists', () => {
+    const html = '<p>No footnotes.</p>';
+    const result = extractHtmlFootnoteSection(html);
+    expect(result.html).toBe(html);
+    expect(result.definitions).toBe('');
+  });
+
+  it('extracts section from markdownToHtml output (li structure)', () => {
+    const html = '<p>Text</p><section class="footnotes" data-footnotes><hr><ol><li data-footnote-id="1"><p>Footnote text.</p></li></ol></section>';
+    const result = extractHtmlFootnoteSection(html);
+    expect(result.html).toBe('<p>Text</p>');
+    expect(result.definitions).toBe('[^1]: Footnote text.');
+  });
+
+  it('extracts section with data-definitions attribute (Tiptap roundtrip)', () => {
+    const defs = JSON.stringify([{ label: '1', content: 'From attribute.' }]);
+    const encoded = encodeURIComponent(defs);
+    const html = `<p>Text</p><section class="footnotes" data-footnotes="" data-definitions="${encoded}"><hr><ol><li data-footnote-id="1"><p>From attribute.</p></li></ol></section>`;
+    const result = extractHtmlFootnoteSection(html);
+    expect(result.html).toBe('<p>Text</p>');
+    expect(result.definitions).toBe('[^1]: From attribute.');
+  });
+
+  it('extracts multiple definitions', () => {
+    const html = '<p>Text</p><section class="footnotes" data-footnotes><hr><ol><li data-footnote-id="1"><p>First.</p></li><li data-footnote-id="2"><p>Second.</p></li></ol></section>';
+    const result = extractHtmlFootnoteSection(html);
+    expect(result.definitions).toBe('[^1]: First.\n[^2]: Second.');
+  });
+
+  it('decodes HTML entities in definition content', () => {
+    const html = '<section class="footnotes" data-footnotes><hr><ol><li data-footnote-id="1"><p>Use &lt;div&gt; for layout.</p></li></ol></section>';
+    const result = extractHtmlFootnoteSection(html);
+    expect(result.definitions).toBe('[^1]: Use <div> for layout.');
+  });
+});

--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -707,6 +707,110 @@ describe('line ending preservation through conversion', () => {
   });
 });
 
+describe('footnotes in markdownToHtml', () => {
+  it('converts footnote references to <sup> elements', () => {
+    const md = 'Text with footnote[^1].\n\n[^1]: Footnote content.';
+    const result = markdownToHtml(md);
+    expect(result).toContain('data-footnote-ref="1"');
+    expect(result).toContain('>1</sup>');
+  });
+
+  it('builds footnotes section at end of HTML', () => {
+    const md = 'Text[^1].\n\n[^1]: Definition here.';
+    const result = markdownToHtml(md);
+    expect(result).toContain('<section class="footnotes" data-footnotes>');
+    expect(result).toContain('data-footnote-id="1"');
+    expect(result).toContain('Definition here.');
+  });
+
+  it('handles named footnote labels', () => {
+    const md = 'Text[^note].\n\n[^note]: Named footnote.';
+    const result = markdownToHtml(md);
+    expect(result).toContain('data-footnote-ref="note"');
+    expect(result).toContain('data-footnote-id="note"');
+  });
+
+  it('does not convert refs inside inline code', () => {
+    const md = '`[^1]` and [^1].\n\n[^1]: Real footnote.';
+    const result = markdownToHtml(md);
+    // The one inside <code> should remain as text
+    expect(result).toContain('<code>[^1]</code>');
+    // The one outside should be converted
+    expect(result).toContain('data-footnote-ref="1"');
+  });
+
+  it('produces no section when there are no footnotes', () => {
+    const md = 'Regular text without footnotes.';
+    const result = markdownToHtml(md);
+    expect(result).not.toContain('data-footnotes');
+  });
+});
+
+describe('footnotes in htmlToMarkdown', () => {
+  it('converts <sup> footnote refs to [^label]', () => {
+    const html = '<p>Text <sup class="footnote-ref" data-footnote-ref="1">1</sup>.</p><section class="footnotes" data-footnotes><hr><ol><li data-footnote-id="1"><p>Footnote.</p></li></ol></section>';
+    const result = htmlToMarkdown(html);
+    expect(result).toContain('[^1]');
+    expect(result).toContain('[^1]: Footnote.');
+  });
+
+  it('extracts multiple definitions', () => {
+    const html = '<p>A<sup class="footnote-ref" data-footnote-ref="1">1</sup> B<sup class="footnote-ref" data-footnote-ref="2">2</sup></p><section class="footnotes" data-footnotes><hr><ol><li data-footnote-id="1"><p>First.</p></li><li data-footnote-id="2"><p>Second.</p></li></ol></section>';
+    const result = htmlToMarkdown(html);
+    expect(result).toContain('[^1]');
+    expect(result).toContain('[^2]');
+    expect(result).toContain('[^1]: First.');
+    expect(result).toContain('[^2]: Second.');
+  });
+});
+
+describe('footnote round-trip', () => {
+  it('preserves simple footnote through round-trip', () => {
+    const original = 'Text with footnote[^1].\n\n[^1]: Footnote content.';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('[^1]');
+    expect(roundTrip).toContain('[^1]: Footnote content.');
+  });
+
+  it('preserves multiple footnotes through round-trip', () => {
+    const original = 'First[^1] and second[^2].\n\n[^1]: Note one.\n[^2]: Note two.';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('[^1]');
+    expect(roundTrip).toContain('[^2]');
+    expect(roundTrip).toContain('[^1]: Note one.');
+    expect(roundTrip).toContain('[^2]: Note two.');
+  });
+
+  it('preserves named footnote labels through round-trip', () => {
+    const original = 'Text[^note].\n\n[^note]: Named footnote.';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('[^note]');
+    expect(roundTrip).toContain('[^note]: Named footnote.');
+  });
+
+  it('preserves footnotes alongside other content', () => {
+    const original = '# Title\n\nParagraph with footnote[^1] and **bold**.\n\n- List item\n\n[^1]: The footnote.';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('# Title');
+    expect(roundTrip).toContain('[^1]');
+    expect(roundTrip).toContain('**bold**');
+    expect(roundTrip).toContain('- List item');
+    expect(roundTrip).toContain('[^1]: The footnote.');
+  });
+
+  it('preserves footnote ref inside inline code unchanged', () => {
+    const original = 'Use `[^1]` syntax for footnotes[^1].\n\n[^1]: Explanation.';
+    const html = markdownToHtml(original);
+    const roundTrip = htmlToMarkdown(html);
+    expect(roundTrip).toContain('`[^1]`');
+    expect(roundTrip).toContain('[^1]: Explanation.');
+  });
+});
+
 describe('markdownToHtml trailing whitespace fix (#53)', () => {
   it('should not return HTML with trailing newlines', () => {
     const result = markdownToHtml('Hello\n\n');

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -52,6 +52,7 @@ import { watch, ref, nextTick, computed } from "vue";
 import { Extension, Node, mergeAttributes, textblockTypeInputRule } from "@tiptap/core";
 import { useEditorZoom } from "../composables/useEditorZoom";
 import { useSettings } from "../composables/useSettings";
+import { useFootnotes } from "../composables/useFootnotes";
 import { resolveEditorImages, getDirectoryFromFilePath } from "../utils/image-resolver";
 import TableContextMenu from "./TableContextMenu.vue";
 import ImagePreview from "./ImagePreview.vue";
@@ -68,6 +69,7 @@ let imageResolutionInProgress = false;
 let lastSavedHtml = '';
 import { MermaidExtension } from "../extensions/MermaidExtension";
 import { PageBreakExtension } from "../extensions/PageBreakExtension";
+import { FootnoteRef, FootnoteSection } from "../extensions/FootnoteExtension";
 import { useI18n } from "../i18n";
 
 const { t } = useI18n();
@@ -172,6 +174,8 @@ const contextMenuY = ref(0);
 const showImagePreview = ref(false);
 const previewImageSrc = ref('');
 const previewImageAlt = ref('');
+
+
 
 // Custom extension for list keyboard shortcuts (Tab/Shift+Tab indentation)
 const ListKeymap = Extension.create({
@@ -383,6 +387,8 @@ const editor = useEditor({
     }),
     MermaidExtension,
     PageBreakExtension,
+    FootnoteRef,
+    FootnoteSection,
     CharacterCount.configure({
       limit: null,
     }),
@@ -393,6 +399,7 @@ const editor = useEditor({
     if (settingContentCount === 0) {
       emit("update:hasChanges", html !== lastSavedHtml);
     }
+    footnotes.consumePendingInsert(ed);
     // Defer image resolution to next frame to avoid conflicting with ProseMirror's
     // current update cycle. Stop the DOM observer so blob URL changes don't get
     // synced back into the document model (which would corrupt save/roundtrip).
@@ -493,11 +500,16 @@ watch(
   }
 );
 
-// Handle clicks on links and images
+// Footnote interactions (tooltip, popover, auto-open after toolbar insert)
+const footnotes = useFootnotes(editor, editorContainerRef);
+
+// Handle clicks on links, images, and footnote refs
 const handleEditorClick = (event: MouseEvent) => {
+  if (footnotes.handleClick(event)) return;
+
   const target = event.target as HTMLElement;
 
-  // Check if clicked element is an image — open preview
+  // Image — open preview
   if (target.tagName === 'IMG' && target.classList.contains('editor-image')) {
     const img = target as HTMLImageElement;
     if (img.src) {
@@ -508,15 +520,13 @@ const handleEditorClick = (event: MouseEvent) => {
     }
   }
 
-  // Check if clicked element is a link or is inside a link
+  // Link
   const link = target.closest('a');
   if (link) {
     event.preventDefault();
     event.stopPropagation();
     const href = link.getAttribute('href');
-    if (href) {
-      emit('linkClick', href);
-    }
+    if (href) emit('linkClick', href);
   }
 };
 
@@ -565,7 +575,7 @@ defineExpose({ editor });
 </script>
 
 <template>
-  <div class="editor-container" ref="editorContainerRef" @click="handleEditorClick" @contextmenu="handleContextMenu">
+  <div class="editor-container" ref="editorContainerRef" @click="handleEditorClick" @contextmenu="handleContextMenu" @mouseover="footnotes.handleMouseOver" @mouseout="footnotes.handleMouseOut">
     <EditorContent :editor="editor" class="editor-content" :style="editorZoomStyle" />
     <TableContextMenu
       v-if="showContextMenu"
@@ -580,6 +590,34 @@ defineExpose({ editor });
       :alt="previewImageAlt"
       @close="showImagePreview = false"
     />
+    <div
+      v-if="footnotes.tooltip.value.visible"
+      class="footnote-tooltip"
+      :style="{ left: footnotes.tooltip.value.x + 'px', top: footnotes.tooltip.value.y + 'px' }"
+    >{{ footnotes.tooltip.value.content }}</div>
+    <div
+      v-if="footnotes.popover.value.visible"
+      :ref="(el) => (footnotes.popoverRef.value = el as HTMLDivElement)"
+      class="footnote-popover"
+      :style="{ left: footnotes.popover.value.x + 'px', top: footnotes.popover.value.y + 'px' }"
+      @click.stop
+    >
+      <div class="footnote-popover-header">
+        <span class="footnote-popover-label">[^{{ footnotes.popover.value.label }}]</span>
+        <button class="footnote-popover-close" @click="footnotes.closePopover" title="Close (Esc)">&#x2715;</button>
+      </div>
+      <textarea
+        v-model="footnotes.popover.value.content"
+        class="footnote-popover-textarea"
+        rows="3"
+        placeholder="Footnote text..."
+        @keydown="footnotes.handlePopoverKeydown"
+      ></textarea>
+      <div class="footnote-popover-footer">
+        <span class="footnote-popover-hint">Enter — save · Esc — cancel</span>
+        <button class="footnote-popover-save" @click="footnotes.savePopover">Save</button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -957,5 +995,159 @@ defineExpose({ editor });
 
 .character-count.danger {
   color: var(--danger-light);
+}
+
+/* Footnote reference (superscript number in text) */
+.editor-content .tiptap sup.footnote-ref {
+  font-size: 0.75em;
+  line-height: 0;
+  position: relative;
+  vertical-align: super;
+  color: var(--link-color);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.editor-content .tiptap sup.footnote-ref:hover {
+  color: var(--link-hover);
+  text-decoration: underline;
+}
+
+/* Footnote hover tooltip (Obsidian-style) */
+.footnote-tooltip {
+  position: absolute;
+  transform: translateX(-50%) translateY(-100%);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 400px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  box-shadow: var(--shadow-sm);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+/* Footnote edit popover (mini-modal above sup) */
+.footnote-popover {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  padding: 10px 12px;
+  width: 340px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+  z-index: 1001;
+}
+
+.footnote-popover-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.footnote-popover-label {
+  font-family: var(--code-font-family, 'Fira Code', 'Consolas', monospace);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--link-color);
+}
+
+.footnote-popover-close {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 12px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.footnote-popover-close:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.footnote-popover-textarea {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  font-family: inherit;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-input, var(--bg-primary));
+  color: var(--text-primary);
+  resize: vertical;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.footnote-popover-textarea:focus {
+  border-color: var(--primary);
+}
+
+.footnote-popover-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 6px;
+}
+
+.footnote-popover-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.footnote-popover-save {
+  padding: 4px 12px;
+  font-size: 12px;
+  border: none;
+  border-radius: 4px;
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.footnote-popover-save:hover {
+  background: var(--primary-hover);
+}
+
+
+/* Footnotes section at document end */
+.editor-content .tiptap section.footnotes {
+  margin-top: 2em;
+  padding-top: 0.5em;
+  font-size: 0.9em;
+  color: var(--text-muted);
+}
+
+.editor-content .tiptap section.footnotes hr {
+  border: none;
+  border-top: 1px solid var(--border-primary);
+  margin-bottom: 1em;
+}
+
+.editor-content .tiptap section.footnotes ol {
+  padding-left: 1.5em;
+  margin: 0;
+}
+
+.editor-content .tiptap section.footnotes li {
+  margin: 0.3em 0;
+}
+
+.editor-content .tiptap section.footnotes li p {
+  margin: 0;
+  display: inline;
 }
 </style>

--- a/src/components/FootnoteNode.vue
+++ b/src/components/FootnoteNode.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import { NodeViewWrapper } from '@tiptap/vue-3';
+import { computed, ref, nextTick } from 'vue';
+import { useI18n } from '../i18n';
+import type { FootnoteDefinition } from '../utils/footnote-utils';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  node: {
+    attrs: {
+      definitions: string;
+    };
+  };
+  updateAttributes: (attrs: Record<string, unknown>) => void;
+  selected: boolean;
+}>();
+
+const defs = computed<FootnoteDefinition[]>(() => {
+  try {
+    return JSON.parse(props.node.attrs.definitions || '[]');
+  } catch {
+    return [];
+  }
+});
+
+const editingIndex = ref<number | null>(null);
+const editContent = ref('');
+
+const startEdit = (index: number) => {
+  editContent.value = defs.value[index].content;
+  editingIndex.value = index;
+  nextTick(() => {
+    const el = document.querySelector(`.footnote-item[data-index="${index}"] .footnote-edit-input`) as HTMLTextAreaElement | null;
+    el?.focus();
+  });
+};
+
+const saveEdit = () => {
+  if (editingIndex.value === null) return;
+  const updated = [...defs.value];
+  updated[editingIndex.value] = { ...updated[editingIndex.value], content: editContent.value };
+  props.updateAttributes({ definitions: JSON.stringify(updated) });
+  editingIndex.value = null;
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    saveEdit();
+  } else if (e.key === 'Escape') {
+    editingIndex.value = null;
+  }
+};
+
+// Dispatch a bubbling DOM event so useFootnotes in Editor.vue can scroll to the ref.
+const emitBacklink = (e: MouseEvent, label: string) => {
+  e.stopPropagation();
+  (e.currentTarget as HTMLElement).dispatchEvent(
+    new CustomEvent('mermark-footnote-backlink', { detail: { label }, bubbles: true }),
+  );
+};
+
+// Called from Editor.vue via DOM query + click simulation
+const focusDefinition = (label: string) => {
+  const idx = defs.value.findIndex(d => d.label === label);
+  if (idx !== -1) startEdit(idx);
+};
+
+defineExpose({ focusDefinition });
+</script>
+
+<template>
+  <NodeViewWrapper class="footnote-section-wrapper" :class="{ selected: props.selected }">
+    <div class="footnote-header">
+      <span class="footnote-label">{{ t.footnotes || 'Footnotes' }}</span>
+    </div>
+    <ol class="footnote-list">
+      <li
+        v-for="(def, index) in defs"
+        :key="def.label"
+        class="footnote-item"
+        :data-index="index"
+        :data-footnote-label="def.label"
+      >
+        <span class="footnote-def-index">{{ index + 1 }}.</span>
+        <!-- Read mode -->
+        <span
+          v-if="editingIndex !== index"
+          class="footnote-def-content"
+          :class="{ empty: !def.content }"
+          @click="startEdit(index)"
+        >{{ def.content || t.footnoteContentPlaceholder || 'Click to add text...' }}</span>
+        <!-- Edit mode -->
+        <textarea
+          v-else
+          v-model="editContent"
+          class="footnote-edit-input"
+          rows="2"
+          @keydown="handleKeydown"
+          @blur="saveEdit"
+        ></textarea>
+        <!-- Backlink to ref in text -->
+        <button
+          class="footnote-backlink"
+          :title="t.footnoteBacklink || 'Jump to reference'"
+          @click="emitBacklink($event, def.label)"
+        >&#x21a9;</button>
+      </li>
+    </ol>
+  </NodeViewWrapper>
+</template>
+
+<style scoped>
+.footnote-section-wrapper {
+  margin: 2em 0 1em;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-primary);
+}
+
+.footnote-header {
+  margin-bottom: 6px;
+}
+
+.footnote-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.footnote-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.footnote-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.9em;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.footnote-def-index {
+  font-size: 0.85em;
+  font-weight: 600;
+  color: var(--text-muted);
+  min-width: 20px;
+  flex-shrink: 0;
+}
+
+.footnote-def-content {
+  flex: 1;
+  white-space: pre-wrap;
+  cursor: text;
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: background 0.15s;
+}
+
+.footnote-def-content:hover {
+  background: var(--bg-tertiary, rgba(255,255,255,0.05));
+}
+
+.footnote-def-content.empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.footnote-edit-input {
+  flex: 1;
+  padding: 4px 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  font-family: inherit;
+  border: 1px solid var(--primary);
+  border-radius: 4px;
+  background: var(--bg-input, var(--bg-primary));
+  color: var(--text-primary);
+  resize: vertical;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.footnote-backlink {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  font-size: 14px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  opacity: 0;
+}
+
+.footnote-item:hover .footnote-backlink {
+  opacity: 1;
+}
+
+.footnote-backlink:hover {
+  background: var(--primary);
+  color: white;
+}
+
+/* Prominent pulse animation for both ref (sup) and definition (li) on navigation.
+   Uses box-shadow rings so it works for inline and block elements alike. */
+:global(.footnote-highlight) {
+  border-radius: 4px;
+  animation: footnote-pulse 3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  z-index: 2;
+}
+
+@keyframes footnote-pulse {
+  0% {
+    background: rgba(59, 130, 246, 0.85);
+    box-shadow:
+      0 0 0 4px rgba(59, 130, 246, 0.7),
+      0 0 0 10px rgba(59, 130, 246, 0.25),
+      0 0 22px 4px rgba(59, 130, 246, 0.55);
+    color: white;
+  }
+  35% {
+    background: rgba(59, 130, 246, 0.55);
+    box-shadow:
+      0 0 0 5px rgba(59, 130, 246, 0.5),
+      0 0 0 12px rgba(59, 130, 246, 0.18),
+      0 0 18px 4px rgba(59, 130, 246, 0.4);
+    color: white;
+  }
+  70% {
+    background: rgba(59, 130, 246, 0.2);
+    box-shadow:
+      0 0 0 2px rgba(59, 130, 246, 0.2),
+      0 0 10px 2px rgba(59, 130, 246, 0.15);
+  }
+  100% {
+    background: transparent;
+    box-shadow: none;
+  }
+}
+</style>

--- a/src/components/TableOfContents.vue
+++ b/src/components/TableOfContents.vue
@@ -11,6 +11,7 @@ interface TocItem {
   text: string;
   id: string;
   pos: number;
+  kind?: 'heading' | 'footnotes';
 }
 
 const emit = defineEmits<{
@@ -28,48 +29,71 @@ const extractHeadings = () => {
 
   const items: TocItem[] = [];
   const doc = editor.value.state.doc;
+  let footnotesPos: number | null = null;
 
   doc.descendants((node, pos) => {
     if (node.type.name === 'heading') {
       const level = node.attrs.level as number;
       const text = node.textContent;
       if (text.trim()) {
-        const id = `toc-heading-${pos}`;
-        items.push({ level, text, id, pos });
+        items.push({ level, text, id: `toc-heading-${pos}`, pos, kind: 'heading' });
       }
+    } else if (node.type.name === 'footnoteSection') {
+      footnotesPos = pos;
     }
   });
+
+  // Append Footnotes entry at the end if section exists
+  if (footnotesPos !== null) {
+    items.push({
+      level: 0,
+      text: t.value.footnotes || 'Footnotes',
+      id: 'toc-footnotes',
+      pos: footnotesPos,
+      kind: 'footnotes',
+    });
+  }
 
   headings.value = items;
 };
 
-// Compute min heading level for proper indentation
+// Compute min heading level for proper indentation (skip footnotes entry at level 0)
 const minLevel = computed(() => {
-  if (headings.value.length === 0) return 1;
-  return Math.min(...headings.value.map(h => h.level));
+  const realHeadings = headings.value.filter(h => h.kind !== 'footnotes');
+  if (realHeadings.length === 0) return 1;
+  return Math.min(...realHeadings.map(h => h.level));
 });
+
+const scrollContainerTo = (container: Element, target: Element) => {
+  const containerRect = container.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const offset = targetRect.top - containerRect.top + container.scrollTop - 20;
+  container.scrollTo({ top: offset, behavior: 'smooth' });
+};
 
 const scrollToHeading = (item: TocItem) => {
   if (!editor?.value) return;
 
-  // Focus editor and set cursor to heading position
+  // Footnotes entry: direct DOM scroll to section wrapper (atom block, no inner content)
+  if (item.kind === 'footnotes') {
+    editor.value.commands.focus();
+    const container = document.querySelector('.editor-container');
+    const section = container?.querySelector('.footnote-section-wrapper');
+    if (container && section) scrollContainerTo(container, section);
+    activeHeadingId.value = item.id;
+    return;
+  }
+
+  // Regular heading: cursor + scroll to DOM element
   editor.value.commands.focus();
   editor.value.commands.setTextSelection(item.pos + 1);
 
-  // Find the DOM element for this heading and scroll to it
   const { node } = editor.value.view.domAtPos(item.pos + 1);
-  const headingEl = node instanceof HTMLElement
-    ? node
-    : node.parentElement;
+  const headingEl = node instanceof HTMLElement ? node : node.parentElement;
 
   if (headingEl) {
     const container = headingEl.closest('.editor-container');
-    if (container) {
-      const containerRect = container.getBoundingClientRect();
-      const headingRect = headingEl.getBoundingClientRect();
-      const offset = headingRect.top - containerRect.top + container.scrollTop - 20;
-      container.scrollTo({ top: offset, behavior: 'smooth' });
-    }
+    if (container) scrollContainerTo(container, headingEl);
   }
 
   activeHeadingId.value = item.id;
@@ -125,13 +149,16 @@ onUnmounted(() => {
           class="toc-item"
           :class="[
             `toc-level-${item.level}`,
-            { active: activeHeadingId === item.id }
+            { active: activeHeadingId === item.id, 'toc-footnotes-entry': item.kind === 'footnotes' },
           ]"
-          :style="{ paddingLeft: `${(item.level - minLevel) * 16 + 12}px` }"
+          :style="{ paddingLeft: `${Math.max(item.level - minLevel, 0) * 16 + 12}px` }"
           @click="scrollToHeading(item)"
           :title="item.text"
         >
-          <span class="toc-level-indicator">H{{ item.level }}</span>
+          <span class="toc-level-indicator">
+            <template v-if="item.kind === 'footnotes'">&sect;</template>
+            <template v-else>H{{ item.level }}</template>
+          </span>
           <span class="toc-item-text">{{ item.text }}</span>
         </button>
       </nav>
@@ -259,6 +286,27 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Footnotes entry */
+.toc-footnotes-entry {
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border-primary);
+  font-weight: 500;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.toc-footnotes-entry:hover {
+  color: var(--text-primary);
+}
+
+.toc-footnotes-entry .toc-level-indicator {
+  font-size: 13px;
+  padding: 0;
+  background: transparent;
 }
 
 /* Heading level font sizes */

--- a/src/components/ToolbarItemRenderer.vue
+++ b/src/components/ToolbarItemRenderer.vue
@@ -63,6 +63,7 @@ const {
   insertImageFromFile,
   showTokenMenu,
   insertMermaid,
+  insertFootnote,
   editor,
   t,
 } = useToolbarActions();
@@ -71,7 +72,7 @@ const needsEditor = (id: string) => {
   const editorItems = [
     'undo', 'redo', 'heading-select', 'bold', 'italic', 'strikethrough', 'inline-code',
     'bullet-list', 'ordered-list', 'task-list', 'blockquote', 'code-block', 'horizontal-rule',
-    'link', 'image', 'table', 'mermaid',
+    'link', 'image', 'table', 'mermaid', 'footnote',
   ];
   return editorItems.includes(id);
 };
@@ -92,7 +93,7 @@ const showLabel = (id: string) => {
   // Items that always show labels (not icon-only)
   const labelItems = [
     'new-file', 'open-file', 'save-file', 'save-file-as', 'export-pdf',
-    'mermaid', 'toggle-toc', 'toggle-code-view', 'toggle-split-view',
+    'mermaid', 'footnote', 'toggle-toc', 'toggle-code-view', 'toggle-split-view',
     'toggle-diff', 'compare-tabs',
   ];
   return labelItems.includes(id);
@@ -362,6 +363,16 @@ const showLabel = (id: string) => {
     <span v-if="showLabel(itemId)">{{ t.mermaid }}</span>
   </button>
 
+  <!-- Footnote -->
+  <button v-else-if="itemId === 'footnote'" @mousedown.prevent @click="insertFootnote" class="toolbar-btn footnote-btn" :class="{ 'icon-only': !showLabel(itemId) }" :title="t.insertFootnote" :disabled="isDisabled(itemId)">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M4 19h16"/>
+      <text x="7" y="15" font-size="14" font-weight="bold" fill="currentColor" stroke="none" font-family="serif">f</text>
+      <text x="14" y="10" font-size="8" font-weight="bold" fill="currentColor" stroke="none">n</text>
+    </svg>
+    <span v-if="showLabel(itemId)">{{ t.footnote }}</span>
+  </button>
+
   <!-- Stats: characters + words + tokens as one group -->
   <div v-else-if="itemId === 'stats'" class="stats-display">
     <span class="stats-item">{{ characterCount }} {{ t.characters }}</span>
@@ -551,6 +562,9 @@ const showLabel = (id: string) => {
 /* Special button styles */
 .mermaid-btn { background: var(--mermaid-bg); border-color: var(--mermaid-border); color: var(--mermaid-color); }
 .mermaid-btn:hover { background: var(--mermaid-hover-bg); border-color: var(--mermaid-hover-border); }
+
+.footnote-btn { background: var(--mermaid-bg); border-color: var(--mermaid-border); color: var(--mermaid-color); }
+.footnote-btn:hover { background: var(--mermaid-hover-bg); border-color: var(--mermaid-hover-border); }
 
 .shortcuts-btn { color: var(--text-muted); }
 .shortcuts-btn:hover { color: var(--text-primary); }

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { markdownToHtml } from '../utils/markdown-converter';
 import { useI18n } from '../i18n';
 
@@ -16,6 +16,8 @@ const props = withDefaults(defineProps<{
   isUpdating: false,
   error: null,
 });
+
+const notesExpanded = ref(true);
 
 const notesHtml = computed(() => {
   if (!props.notes) return '';
@@ -36,7 +38,20 @@ const emit = defineEmits<{
       </div>
       <div class="dialog-content">
         <p>{{ t.newVersionAvailable }} <strong>{{ version }}</strong></p>
-        <div v-if="notes" class="update-notes whats-new-content" v-html="notesHtml"></div>
+        <div v-if="notes" class="update-notes-container">
+          <button
+            class="update-notes-toggle"
+            :class="{ expanded: notesExpanded }"
+            @click="notesExpanded = !notesExpanded"
+            :aria-expanded="notesExpanded"
+          >
+            <svg class="toggle-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"/>
+            </svg>
+            <span>{{ t.whatsNew || "What's new" }}</span>
+          </button>
+          <div v-show="notesExpanded" class="update-notes whats-new-content" v-html="notesHtml"></div>
+        </div>
         <div v-if="isUpdating" class="update-progress">
           <p>{{ t.downloadingUpdate }}</p>
           <div class="progress-bar">
@@ -143,15 +158,52 @@ const emit = defineEmits<{
   background: var(--primary-hover);
 }
 
+.update-notes-container {
+  margin-top: 12px;
+}
+
+.update-notes-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--dialog-actions-bg);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+  text-align: left;
+}
+
+.update-notes-toggle:hover {
+  background: var(--border-primary);
+  color: var(--text-primary);
+}
+
+.toggle-chevron {
+  transition: transform 0.2s;
+  flex-shrink: 0;
+  transform: rotate(-90deg);
+}
+
+.update-notes-toggle.expanded .toggle-chevron {
+  transform: rotate(0);
+}
+
 .update-notes {
   background: var(--dialog-actions-bg);
   padding: 12px;
   border-radius: 6px;
-  margin-top: 12px;
+  margin-top: 6px;
   font-size: 13px;
   color: var(--text-secondary);
   max-height: 300px;
   overflow-y: auto;
+  border: 1px solid var(--border-primary);
 }
 
 .update-progress {

--- a/src/composables/useAutoUpdate.ts
+++ b/src/composables/useAutoUpdate.ts
@@ -16,6 +16,22 @@ export interface UseAutoUpdateReturn {
   closeUpdateDialog: () => void;
 }
 
+const DISMISSED_KEY = 'mermark-dismissed-update-version';
+const GITHUB_REPO = 'Vesperino/MerMarkEditor';
+
+/** Fetch release notes from GitHub API as fallback when Tauri updater body is empty. */
+async function fetchGitHubReleaseNotes(version: string): Promise<string> {
+  const tag = version.startsWith('v') ? version : `v${version}`;
+  try {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${tag}`);
+    if (!res.ok) return '';
+    const data = await res.json();
+    return typeof data?.body === 'string' ? data.body : '';
+  } catch {
+    return '';
+  }
+}
+
 export function useAutoUpdate(): UseAutoUpdateReturn {
   const showUpdateDialog = ref(false);
   const updateInfo = ref<UpdateInfo | null>(null);
@@ -27,17 +43,21 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
     try {
       const { check } = await import('@tauri-apps/plugin-updater');
       const update = await check();
+      if (!update) return;
 
-      if (update) {
-        updateInfo.value = {
-          version: update.version,
-          notes: update.body || '',
-        };
-        showUpdateDialog.value = true;
+      // Skip if user already dismissed this exact version
+      if (localStorage.getItem(DISMISSED_KEY) === update.version) return;
+
+      // Prefer Tauri updater body; fall back to GitHub Releases API
+      let notes = update.body || '';
+      if (!notes.trim()) {
+        notes = await fetchGitHubReleaseNotes(update.version);
       }
+
+      updateInfo.value = { version: update.version, notes };
+      showUpdateDialog.value = true;
     } catch (error) {
-      // Silently fail if update check fails (might not have endpoints configured)
-      console.log('Sprawdzanie aktualizacji pominięte:', error);
+      console.log('Update check skipped:', error);
     }
   };
 
@@ -55,7 +75,6 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
           if (progress.event === 'Started') {
             updateProgress.value = 0;
           } else if (progress.event === 'Progress') {
-            // Calculate actual percentage based on content length if available
             const progressData = progress.data as { chunkLength?: number; contentLength?: number };
             if (progressData.contentLength && progressData.contentLength > 0) {
               const currentProgress = updateProgress.value * progressData.contentLength / 100;
@@ -69,7 +88,8 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
           }
         });
 
-        // Restart the app after update
+        // Clear dismissal on successful install + relaunch
+        localStorage.removeItem(DISMISSED_KEY);
         const { relaunch } = await import('@tauri-apps/plugin-process');
         await relaunch();
       }
@@ -80,11 +100,14 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
   };
 
   const closeUpdateDialog = (): void => {
-    if (!isUpdating.value) {
-      showUpdateDialog.value = false;
-      updateInfo.value = null;
-      updateError.value = null;
+    if (isUpdating.value) return;
+    // Persist dismissal so the dialog doesn't reappear for this version (fixes HMR/remount loop)
+    if (updateInfo.value?.version) {
+      localStorage.setItem(DISMISSED_KEY, updateInfo.value.version);
     }
+    showUpdateDialog.value = false;
+    updateInfo.value = null;
+    updateError.value = null;
   };
 
   return {

--- a/src/composables/useFootnotes.ts
+++ b/src/composables/useFootnotes.ts
@@ -1,0 +1,271 @@
+import { ref, nextTick, onMounted, onBeforeUnmount, watch, type Ref } from 'vue';
+import type { Editor as VueEditor } from '@tiptap/vue-3';
+import type { Editor as CoreEditor } from '@tiptap/core';
+import type { FootnoteDefinition } from '../utils/footnote-utils';
+
+// Accept either @tiptap/vue-3 or @tiptap/core Editor (onUpdate passes the core variant)
+type AnyEditor = VueEditor | CoreEditor;
+
+interface FootnoteStorage {
+  pendingPopoverLabel: string | null;
+}
+
+export interface FootnoteTooltipState {
+  visible: boolean;
+  content: string;
+  x: number;
+  y: number;
+}
+
+export interface FootnotePopoverState {
+  visible: boolean;
+  label: string;
+  content: string;
+  x: number;
+  y: number;
+}
+
+const POPOVER_RETRY_MAX = 10;
+const POPOVER_RETRY_INTERVAL_MS = 30;
+const HIGHLIGHT_DURATION_MS = 3000;
+
+/**
+ * Footnote interactions: hover tooltip + click popover + auto-open after insert.
+ * Keeps Editor.vue free of footnote-specific glue.
+ */
+export function useFootnotes(
+  editor: Ref<AnyEditor | null | undefined>,
+  containerRef: Ref<HTMLElement | null>,
+) {
+  const tooltip = ref<FootnoteTooltipState>({ visible: false, content: '', x: 0, y: 0 });
+  const popover = ref<FootnotePopoverState>({ visible: false, label: '', content: '', x: 0, y: 0 });
+  const popoverRef = ref<HTMLDivElement | null>(null);
+
+  // --- content lookup ---
+
+  const getDefinition = (label: string): FootnoteDefinition | null => {
+    if (!editor.value) return null;
+    let found: FootnoteDefinition | null = null;
+    editor.value.state.doc.descendants((node) => {
+      if (found) return false;
+      if (node.type.name === 'footnoteSection') {
+        try {
+          const defs: FootnoteDefinition[] = JSON.parse(node.attrs.definitions || '[]');
+          found = defs.find(d => d.label === label) || null;
+        } catch { /* ignore */ }
+        return false;
+      }
+    });
+    return found;
+  };
+
+  const getContent = (label: string): string => getDefinition(label)?.content || '';
+
+  // --- positioning ---
+
+  const relativeTo = (rect: DOMRect) => {
+    const containerRect = containerRef.value?.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2 - (containerRect?.left || 0),
+      y: rect.top - (containerRect?.top || 0),
+    };
+  };
+
+  // --- tooltip ---
+
+  const showTooltip = (label: string, anchor: HTMLElement) => {
+    if (popover.value.visible) return;
+    const display = getContent(label) || '(click to edit)';
+    const { x, y } = relativeTo(anchor.getBoundingClientRect());
+    tooltip.value = {
+      visible: true,
+      content: `[^${label}]: ${display}`,
+      x,
+      y: y - 4,
+    };
+  };
+
+  const hideTooltip = () => { tooltip.value.visible = false; };
+
+  // --- popover ---
+
+  const showPopover = (label: string, anchor: HTMLElement) => {
+    hideTooltip();
+    const rect = anchor.getBoundingClientRect();
+    const { x, y } = relativeTo(rect);
+    popover.value = {
+      visible: true,
+      label,
+      content: getContent(label),
+      x,
+      y: y - 8,
+    };
+    nextTick(() => {
+      const textarea = popoverRef.value?.querySelector('textarea');
+      textarea?.focus();
+    });
+  };
+
+  const showPopoverByLabel = (label: string, attempt = 0): void => {
+    const container = containerRef.value;
+    if (!container) return;
+    const sup = container.querySelector(
+      `sup.footnote-ref[data-footnote-ref="${label}"]`,
+    ) as HTMLElement | null;
+    if (sup) {
+      showPopover(label, sup);
+    } else if (attempt < POPOVER_RETRY_MAX) {
+      setTimeout(() => showPopoverByLabel(label, attempt + 1), POPOVER_RETRY_INTERVAL_MS);
+    }
+  };
+
+  const updateDefinitionContent = (label: string, newContent: string) => {
+    if (!editor.value) return;
+    let done = false;
+    editor.value.state.doc.descendants((node, pos) => {
+      if (done) return false;
+      if (node.type.name === 'footnoteSection') {
+        done = true;
+        try {
+          const defs: FootnoteDefinition[] = JSON.parse(node.attrs.definitions || '[]');
+          const def = defs.find(d => d.label === label);
+          if (def) {
+            def.content = newContent;
+            const tr = editor.value!.state.tr;
+            tr.setNodeMarkup(pos, undefined, { definitions: JSON.stringify(defs) });
+            editor.value!.view.dispatch(tr);
+          }
+        } catch { /* ignore */ }
+        return false;
+      }
+    });
+  };
+
+  const savePopover = () => {
+    if (!popover.value.visible) return;
+    updateDefinitionContent(popover.value.label, popover.value.content);
+    popover.value.visible = false;
+  };
+
+  const closePopover = () => { popover.value.visible = false; };
+
+  const handlePopoverKeydown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      savePopover();
+    } else if (e.key === 'Escape') {
+      closePopover();
+    }
+  };
+
+  // --- event delegation helpers ---
+
+  const isFootnoteRef = (el: HTMLElement): boolean =>
+    el.tagName === 'SUP' && el.classList.contains('footnote-ref');
+
+  const handleMouseOver = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (!isFootnoteRef(target)) return;
+    const label = target.getAttribute('data-footnote-ref');
+    if (label) showTooltip(label, target);
+  };
+
+  const handleMouseOut = (event: MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (isFootnoteRef(target)) hideTooltip();
+  };
+
+  /** Returns true if the click was handled (caller should skip further processing). */
+  const handleClick = (event: MouseEvent): boolean => {
+    const target = event.target as HTMLElement;
+    // Auto-save popover on outside click
+    if (popover.value.visible) {
+      const popoverEl = popoverRef.value;
+      if (popoverEl && !popoverEl.contains(target)) {
+        savePopover();
+      }
+    }
+    if (isFootnoteRef(target)) {
+      event.preventDefault();
+      event.stopPropagation();
+      const label = target.getAttribute('data-footnote-ref');
+      if (label) showPopover(label, target);
+      return true;
+    }
+    return false;
+  };
+
+  /** Call from editor onUpdate: opens popover if toolbar just inserted a footnote. */
+  const consumePendingInsert = (ed: AnyEditor) => {
+    const storage = (ed.storage as unknown as Record<string, FootnoteStorage | undefined>).footnoteSection;
+    const pendingLabel = storage?.pendingPopoverLabel;
+    if (pendingLabel && storage) {
+      storage.pendingPopoverLabel = null;
+      nextTick(() => showPopoverByLabel(pendingLabel));
+    }
+  };
+
+  // --- navigation ---
+
+  const flashElement = (el: HTMLElement) => {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.add('footnote-highlight');
+    setTimeout(() => el.classList.remove('footnote-highlight'), HIGHLIGHT_DURATION_MS);
+  };
+
+  const highlightDefinition = (label: string) => {
+    const item = containerRef.value?.querySelector(
+      `.footnote-item[data-footnote-label="${label}"]`,
+    ) as HTMLElement | null;
+    if (item) flashElement(item);
+  };
+
+  const highlightRef = (label: string) => {
+    const sup = containerRef.value?.querySelector(
+      `sup.footnote-ref[data-footnote-ref="${label}"]`,
+    ) as HTMLElement | null;
+    if (sup) flashElement(sup);
+  };
+
+  // Backlink event from FootnoteNode: scroll+flash the referenced sup
+  const handleBacklink = (e: Event) => {
+    const label = (e as CustomEvent<{ label: string }>).detail?.label;
+    if (label) highlightRef(label);
+  };
+
+  // Register/unregister backlink listener on container (reactively tracks ref changes)
+  let currentContainer: HTMLElement | null = null;
+  const bindContainer = (el: HTMLElement | null) => {
+    if (currentContainer === el) return;
+    if (currentContainer) {
+      currentContainer.removeEventListener('mermark-footnote-backlink', handleBacklink);
+    }
+    currentContainer = el;
+    if (currentContainer) {
+      currentContainer.addEventListener('mermark-footnote-backlink', handleBacklink);
+    }
+  };
+
+  onMounted(() => bindContainer(containerRef.value));
+  watch(containerRef, (el) => bindContainer(el));
+  onBeforeUnmount(() => bindContainer(null));
+
+  return {
+    // state
+    tooltip,
+    popover,
+    popoverRef,
+    // popover actions (template refs)
+    savePopover,
+    closePopover,
+    handlePopoverKeydown,
+    // event delegation (Editor.vue bindings)
+    handleMouseOver,
+    handleMouseOut,
+    handleClick,
+    consumePendingInsert,
+    // navigation
+    highlightDefinition,
+    highlightRef,
+  };
+}

--- a/src/composables/useToolbarActions.ts
+++ b/src/composables/useToolbarActions.ts
@@ -192,6 +192,11 @@ export function useToolbarActions() {
     runCommand((e) => (e.commands as any).insertMermaid());
   };
 
+  // Footnote — chain().focus() preserves selection after toolbar click steals focus
+  const insertFootnote = () => {
+    runCommand((e) => (e.chain() as any).focus().insertFootnote().run());
+  };
+
   // Close all dropdowns
   const closeDropdowns = () => {
     showTableMenu.value = false;
@@ -247,6 +252,9 @@ export function useToolbarActions() {
 
     // Mermaid
     insertMermaid,
+
+    // Footnote
+    insertFootnote,
 
     // Dropdowns
     closeDropdowns,

--- a/src/data/toolbarItems.ts
+++ b/src/data/toolbarItems.ts
@@ -10,6 +10,7 @@ export type ToolbarItemCategory =
   | 'links-media'
   | 'table'
   | 'mermaid'
+  | 'footnote'
   | 'stats'
   | 'zoom'
   | 'view-toggles';
@@ -65,6 +66,9 @@ export const TOOLBAR_ITEMS: ToolbarItemDef[] = [
 
   // Mermaid
   { id: 'mermaid', category: 'mermaid', defaultZone: 'toolbar', defaultOrder: 800, needsEditor: true, labelKey: 'mermaid' },
+
+  // Footnote
+  { id: 'footnote', category: 'footnote', defaultZone: 'toolbar', defaultOrder: 850, needsEditor: true, labelKey: 'footnote' },
 
   // Stats (characters + words + tokens as single movable group)
   { id: 'stats', category: 'stats', defaultZone: 'toolbar', defaultOrder: 900, needsEditor: false, labelKey: 'stats' },

--- a/src/extensions/FootnoteExtension.ts
+++ b/src/extensions/FootnoteExtension.ts
@@ -1,0 +1,217 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import { VueNodeViewRenderer } from '@tiptap/vue-3';
+import { Plugin } from '@tiptap/pm/state';
+import FootnoteNode from '../components/FootnoteNode.vue';
+import type { FootnoteDefinition } from '../utils/footnote-utils';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    footnote: {
+      insertFootnote: () => ReturnType;
+    };
+  }
+}
+
+/**
+ * Inline atom node for footnote references ([^label] in markdown).
+ * Renders as a superscript number: <sup data-footnote-ref="label">N</sup>
+ */
+export const FootnoteRef = Node.create({
+  name: 'footnoteRef',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addAttributes() {
+    return {
+      label: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.getAttribute('data-footnote-ref'),
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes.label) return {};
+          return { 'data-footnote-ref': attributes.label as string };
+        },
+      },
+      index: {
+        default: null,
+        parseHTML: (element: HTMLElement) => element.textContent?.trim() || null,
+        renderHTML: () => ({}),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'sup[data-footnote-ref]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      'sup',
+      mergeAttributes(HTMLAttributes, { class: 'footnote-ref' }),
+      node.attrs.index?.toString() || '?',
+    ];
+  },
+});
+
+/**
+ * Block atom node for the footnotes section at the end of a document.
+ * Stores definitions as a URL-encoded JSON attribute for lossless roundtrip.
+ * Uses a Vue NodeView for interactive editing in the WYSIWYG editor.
+ */
+export const FootnoteSection = Node.create({
+  name: 'footnoteSection',
+  group: 'block',
+  atom: true,
+
+  addAttributes() {
+    return {
+      definitions: {
+        default: '[]',
+        parseHTML(element: HTMLElement) {
+          const encoded = element.getAttribute('data-definitions');
+          if (encoded) {
+            try {
+              const json = decodeURIComponent(encoded);
+              JSON.parse(json);
+              return json;
+            } catch { /* fall through */ }
+          }
+
+          const items = element.querySelectorAll('li[data-footnote-id]');
+          const defs: FootnoteDefinition[] = [];
+          items.forEach(li => {
+            const label = li.getAttribute('data-footnote-id') || '';
+            const p = li.querySelector('p');
+            const content = p ? (p.textContent || '') : (li.textContent || '');
+            defs.push({ label, content: content.trim() });
+          });
+          return JSON.stringify(defs);
+        },
+        renderHTML(attributes: Record<string, unknown>) {
+          return { 'data-definitions': encodeURIComponent(attributes.definitions as string) };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'section[data-footnotes]' }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const defs: FootnoteDefinition[] = JSON.parse(node.attrs.definitions || '[]');
+
+    const listItems: unknown[] = defs.map(def =>
+      ['li', { 'data-footnote-id': def.label }, ['p', {}, def.content]]
+    );
+
+    return [
+      'section',
+      mergeAttributes(HTMLAttributes, { class: 'footnotes', 'data-footnotes': '' }),
+      ['hr'],
+      ['ol', {}, ...listItems],
+    ];
+  },
+
+  addStorage() {
+    return {
+      pendingPopoverLabel: null as string | null,
+    };
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(FootnoteNode as any);
+  },
+
+  // Auto-renumber FootnoteRef nodes by their document order after every edit.
+  // Converges because the plugin returns null when all indexes already match order.
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        appendTransaction(transactions, _oldState, newState) {
+          if (!transactions.some(tr => tr.docChanged)) return null;
+
+          const tr = newState.tr;
+          let changed = false;
+          let n = 1;
+
+          newState.doc.descendants((node, pos) => {
+            if (node.type.name === 'footnoteRef') {
+              if (node.attrs.index !== n) {
+                tr.setNodeMarkup(pos, undefined, { ...node.attrs, index: n });
+                changed = true;
+              }
+              n++;
+            }
+          });
+
+          return changed ? tr : null;
+        },
+      }),
+    ];
+  },
+
+  addCommands() {
+    return {
+      insertFootnote:
+        () =>
+        ({ editor, state, tr, dispatch }) => {
+          // Refuse if cursor is inside the footnote section itself
+          const { $from } = state.selection;
+          for (let d = $from.depth; d >= 0; d--) {
+            if ($from.node(d).type.name === 'footnoteSection') return false;
+          }
+
+          // Scan doc once for section + existing labels
+          let sectionPos: number | null = null;
+          let existingDefs: FootnoteDefinition[] = [];
+          const usedLabels = new Set<string>();
+
+          state.doc.descendants((node, pos) => {
+            if (node.type.name === 'footnoteSection') {
+              sectionPos = pos;
+              try {
+                existingDefs = JSON.parse(node.attrs.definitions || '[]');
+              } catch { existingDefs = []; }
+              existingDefs.forEach(d => usedLabels.add(d.label));
+            } else if (node.type.name === 'footnoteRef' && node.attrs.label) {
+              usedLabels.add(String(node.attrs.label));
+            }
+          });
+
+          let nextNum = 1;
+          while (usedLabels.has(String(nextNum))) nextNum++;
+          const label = String(nextNum);
+          const index = existingDefs.length + 1;
+
+          if (!dispatch) return true;
+
+          // Signal Editor.vue to open popover for this label
+          (editor.storage as unknown as Record<string, { pendingPopoverLabel: string | null }>)
+            .footnoteSection.pendingPopoverLabel = label;
+
+          // Build nodes
+          const refNode = editor.schema.nodes.footnoteRef.create({ label, index });
+          const defsJson = JSON.stringify([...existingDefs, { label, content: '' }]);
+
+          // Single transaction: insert ref at cursor, then update/create section
+          // using tr.mapping.map() to keep section position valid after the insert.
+          const { from, to } = state.selection;
+          tr.replaceWith(from, to, refNode);
+
+          if (sectionPos !== null) {
+            const mapped = tr.mapping.map(sectionPos);
+            tr.setNodeMarkup(mapped, undefined, { definitions: defsJson });
+          } else {
+            const sectionNode = editor.schema.nodes.footnoteSection.create({
+              definitions: defsJson,
+            });
+            tr.insert(tr.doc.content.size, sectionNode);
+          }
+
+          dispatch(tr);
+          return true;
+        },
+    };
+  },
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -68,6 +68,16 @@ export interface Translations {
   mermaid: string;
   insertMermaid: string;
 
+  // Toolbar - Footnotes
+  footnote: string;
+  insertFootnote: string;
+  footnotes: string;
+  addFootnote: string;
+  deleteFootnotes: string;
+  noFootnotes: string;
+  footnoteContentPlaceholder: string;
+  footnoteBacklink: string;
+
   // Toolbar - Code View
   codeView: string;
   visualView: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -62,6 +62,16 @@ const en: Translations = {
   mermaid: 'Mermaid',
   insertMermaid: 'Insert Mermaid diagram',
 
+  // Toolbar - Footnotes
+  footnote: 'Footnote',
+  insertFootnote: 'Insert footnote',
+  footnotes: 'Footnotes',
+  addFootnote: 'Add footnote',
+  deleteFootnotes: 'Delete all footnotes',
+  noFootnotes: 'No footnotes defined. Click + to add one.',
+  footnoteContentPlaceholder: 'Footnote text...',
+  footnoteBacklink: 'Jump to reference',
+
   // Toolbar - Code View
   codeView: 'Code',
   visualView: 'Visual',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -62,6 +62,16 @@ const pl: Translations = {
   mermaid: 'Mermaid',
   insertMermaid: 'Wstaw diagram Mermaid',
 
+  // Toolbar - Footnotes
+  footnote: 'Przypis',
+  insertFootnote: 'Wstaw przypis',
+  footnotes: 'Przypisy',
+  addFootnote: 'Dodaj przypis',
+  deleteFootnotes: 'Usuń wszystkie przypisy',
+  noFootnotes: 'Brak przypisów. Kliknij + aby dodać.',
+  footnoteContentPlaceholder: 'Treść przypisu...',
+  footnoteBacklink: 'Skocz do odnośnika',
+
   // Toolbar - Code View
   codeView: 'Kod',
   visualView: 'Wizualny',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -62,6 +62,16 @@ const zhCN: Translations = {
   mermaid: 'Mermaid',
   insertMermaid: '插入 Mermaid 图表',
 
+  // Toolbar - Footnotes
+  footnote: '脚注',
+  insertFootnote: '插入脚注',
+  footnotes: '脚注',
+  addFootnote: '添加脚注',
+  deleteFootnotes: '删除所有脚注',
+  noFootnotes: '没有脚注。点击 + 添加一个。',
+  footnoteContentPlaceholder: '脚注文本...',
+  footnoteBacklink: '跳转到引用',
+
   // Toolbar - Code View
   codeView: '代码',
   visualView: '可视化',

--- a/src/utils/footnote-utils.ts
+++ b/src/utils/footnote-utils.ts
@@ -1,0 +1,170 @@
+import { escapeHtml, decodeHtmlEntities } from './html-entities';
+
+export interface FootnoteDefinition {
+  label: string;
+  content: string;
+}
+
+/**
+ * Extract footnote definitions ([^label]: content) from markdown.
+ * Handles single-line and multi-line (4-space indented continuation) definitions.
+ * Blank lines terminate a definition unless followed by an indented continuation.
+ */
+export function extractFootnoteDefinitions(md: string): {
+  definitions: FootnoteDefinition[];
+  cleanedMd: string;
+} {
+  const lines = md.split('\n');
+  const definitions: FootnoteDefinition[] = [];
+  const cleanedLines: string[] = [];
+  let currentDef: FootnoteDefinition | null = null;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const defMatch = line.match(/^\[\^([^\]]+)\]:\s*(.*)$/);
+
+    if (defMatch) {
+      if (currentDef) {
+        currentDef.content = currentDef.content.trimEnd();
+        definitions.push(currentDef);
+      }
+      currentDef = { label: defMatch[1], content: defMatch[2] };
+    } else if (currentDef && /^    /.test(line)) {
+      currentDef.content += '\n' + line.slice(4);
+    } else if (currentDef && line.trim() === '') {
+      // Blank line: check if definition continues (next non-blank line is indented)
+      let nextNonBlank = i + 1;
+      while (nextNonBlank < lines.length && lines[nextNonBlank].trim() === '') {
+        nextNonBlank++;
+      }
+      if (nextNonBlank < lines.length && /^    /.test(lines[nextNonBlank])) {
+        currentDef.content += '\n';
+      } else {
+        currentDef.content = currentDef.content.trimEnd();
+        definitions.push(currentDef);
+        currentDef = null;
+        cleanedLines.push(line);
+      }
+    } else {
+      if (currentDef) {
+        currentDef.content = currentDef.content.trimEnd();
+        definitions.push(currentDef);
+        currentDef = null;
+      }
+      cleanedLines.push(line);
+    }
+  }
+
+  if (currentDef) {
+    currentDef.content = currentDef.content.trimEnd();
+    definitions.push(currentDef);
+  }
+
+  return { definitions, cleanedMd: cleanedLines.join('\n') };
+}
+
+/**
+ * Convert [^label] references in text to <sup> HTML elements.
+ * Skips references inside <code> tags (uses regex alternation).
+ */
+export function convertFootnoteRefsToHtml(
+  html: string,
+  definitions: FootnoteDefinition[]
+): string {
+  const labelToIndex = new Map<string, number>();
+  definitions.forEach((def, i) => labelToIndex.set(def.label, i + 1));
+
+  return html.replace(
+    /<code>[\s\S]*?<\/code>|\[\^([^\]]+)\]/g,
+    (match, label) => {
+      if (label === undefined) return match;
+      const index = labelToIndex.get(label);
+      if (index === undefined) return match;
+      return `<sup class="footnote-ref" data-footnote-ref="${escapeHtml(label)}">${index}</sup>`;
+    }
+  );
+}
+
+/**
+ * Build the footnotes section HTML from definitions.
+ * Content is stored as escaped markdown (not converted to HTML).
+ */
+export function buildFootnoteSectionHtml(definitions: FootnoteDefinition[]): string {
+  if (definitions.length === 0) return '';
+
+  let html = '<section class="footnotes" data-footnotes>';
+  html += '<hr>';
+  html += '<ol>';
+
+  for (const def of definitions) {
+    const content = escapeHtml(def.content);
+    html += `<li data-footnote-id="${escapeHtml(def.label)}"><p>${content}</p></li>`;
+  }
+
+  html += '</ol>';
+  html += '</section>';
+  return html;
+}
+
+/**
+ * Convert footnote ref <sup> elements back to markdown [^label] syntax.
+ */
+export function convertHtmlFootnoteRefsToMd(html: string): string {
+  return html.replace(
+    /<sup[^>]*data-footnote-ref="([^"]*)"[^>]*>\d+<\/sup>/gi,
+    '[^$1]'
+  );
+}
+
+/**
+ * Format a single footnote definition as markdown, with 4-space indentation
+ * for continuation lines.
+ */
+function formatDefinitionAsMd(label: string, content: string): string {
+  const lines = content.split('\n');
+  const first = `[^${label}]: ${lines[0]}`;
+  if (lines.length === 1) return first;
+  const rest = lines.slice(1).map(l => l === '' ? '' : '    ' + l).join('\n');
+  return first + '\n' + rest;
+}
+
+/**
+ * Extract the footnotes section from HTML and convert to markdown definitions.
+ * Handles both data-definitions attribute (from Tiptap getHTML) and
+ * <li> DOM structure (from markdownToHtml).
+ */
+export function extractHtmlFootnoteSection(html: string): {
+  html: string;
+  definitions: string;
+} {
+  const match = html.match(/<section[^>]*\sdata-footnotes[^>]*>[\s\S]*?<\/section>/i);
+  if (!match) return { html, definitions: '' };
+
+  const sectionHtml = match[0];
+  const cleanedHtml = html.replace(sectionHtml, '');
+
+  // Primary: try URL-encoded data-definitions attribute (set by Tiptap renderHTML)
+  const dataDefMatch = sectionHtml.match(/data-definitions="([^"]*)"/);
+  if (dataDefMatch) {
+    try {
+      const json = decodeURIComponent(dataDefMatch[1]);
+      const defs: FootnoteDefinition[] = JSON.parse(json);
+      const md = defs.map(d => formatDefinitionAsMd(d.label, d.content)).join('\n');
+      return { html: cleanedHtml, definitions: md };
+    } catch { /* fall through to HTML parsing */ }
+  }
+
+  // Fallback: parse from <li data-footnote-id> elements
+  const liRegex = /<li[^>]*data-footnote-id="([^"]*)"[^>]*>\s*<p>([\s\S]*?)<\/p>\s*<\/li>/gi;
+  const defs: string[] = [];
+  let liMatch;
+  while ((liMatch = liRegex.exec(sectionHtml)) !== null) {
+    const label = liMatch[1];
+    let content = liMatch[2];
+    content = content.replace(/<[^>]+>/g, '');
+    content = decodeHtmlEntities(content);
+    defs.push(formatDefinitionAsMd(label, content));
+  }
+
+  return { html: cleanedHtml, definitions: defs.join('\n') };
+}

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -14,6 +14,13 @@ export {
   extractPageBreaks,
   restoreCodeBlocks,
 } from './markdown-to-html';
+export {
+  extractFootnoteDefinitions,
+  convertFootnoteRefsToHtml,
+  buildFootnoteSectionHtml,
+  convertHtmlFootnoteRefsToMd,
+  extractHtmlFootnoteSection,
+} from './footnote-utils';
 
 import { decodeHtmlEntities, escapeHtml } from './html-entities';
 import { convertInlineToMarkdown, extractMermaidCode, parseHtmlList, processHtmlLists } from './html-to-markdown';
@@ -27,6 +34,13 @@ import {
   extractPageBreaks,
   restoreCodeBlocks,
 } from './markdown-to-html';
+import {
+  extractFootnoteDefinitions,
+  convertFootnoteRefsToHtml,
+  buildFootnoteSectionHtml,
+  convertHtmlFootnoteRefsToMd,
+  extractHtmlFootnoteSection,
+} from './footnote-utils';
 
 export function htmlToMarkdown(html: string): string {
   let md = html.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
@@ -59,6 +73,11 @@ export function htmlToMarkdown(html: string): string {
     protectedBlocks.push(`\n\`\`\`\n${decodedCode}\n\`\`\`\n`);
     return placeholder;
   });
+
+  // Footnotes — extract section and convert refs before other processing
+  const footnoteSection = extractHtmlFootnoteSection(md);
+  md = footnoteSection.html;
+  md = convertHtmlFootnoteRefsToMd(md);
 
   // Tables - convert links inside cells before stripping other tags
   md = md.replace(/<table[^>]*>([\s\S]*?)<\/table>/gi, (_, tableContent) => {
@@ -197,7 +216,14 @@ export function htmlToMarkdown(html: string): string {
 
   // Clean up whitespace
   md = md.replace(/\n{3,}/g, '\n\n');
-  return md.trim();
+  md = md.trim();
+
+  // Append footnote definitions at end
+  if (footnoteSection.definitions) {
+    md += '\n\n' + footnoteSection.definitions;
+  }
+
+  return md;
 }
 
 export function markdownToHtml(md: string): string {
@@ -208,6 +234,11 @@ export function markdownToHtml(md: string): string {
   const extracted = extractCodeBlocks(html);
   html = extracted.html;
   const codeBlocks = extracted.codeBlocks;
+
+  // Extract footnote definitions before HTML processing
+  const footnotes = extractFootnoteDefinitions(html);
+  html = footnotes.cleanedMd;
+  const footnoteDefs = footnotes.definitions;
 
   html = escapeHtml(html);
 
@@ -226,6 +257,9 @@ export function markdownToHtml(md: string): string {
 
   // Formatting + inline code
   html = convertMarkdownFormatting(html);
+
+  // Footnote references (after inline code conversion, before links)
+  html = convertFootnoteRefsToHtml(html, footnoteDefs);
 
   // Links and images
   html = convertMarkdownLinksAndImages(html);
@@ -249,6 +283,9 @@ export function markdownToHtml(md: string): string {
   // Restore page breaks
   html = html.replace(/<p>__PAGE_BREAK__<\/p>/g, '<div class="page-break"></div>');
   html = html.replace(/__PAGE_BREAK__/g, '<div class="page-break"></div>');
+
+  // Append footnotes section
+  html += buildFootnoteSectionHtml(footnoteDefs);
 
   return html.trimEnd();
 }

--- a/test-footnotes.md
+++ b/test-footnotes.md
@@ -1,0 +1,53 @@
+# Footnotes Test Document
+
+## Basic Footnotes
+
+This is a paragraph with a simple footnote[^1]. The reference appears as a superscript number.
+
+Here is another paragraph with a named footnote[^note]. Named labels work too.
+
+## Multiple References
+
+You can use multiple footnotes[^2] in the same paragraph[^3]. They are numbered sequentially.
+
+## Footnotes with Formatting
+
+This paragraph references a footnote with **bold** text in the body[^4].
+
+## Footnote in Context
+
+Footnotes are commonly used in academic writing[^5], technical documentation[^2], and legal texts. Notice that [^2] is referenced twice.
+
+## Edge Cases
+
+### Inline Code
+
+The syntax `[^1]` should not be converted when inside inline code.
+
+### Code Block
+
+```
+[^1]: This is inside a code block and should NOT be treated as a footnote.
+```
+
+### Footnote-free Section
+
+This section has no footnotes at all. It should render normally.
+
+---
+
+## Multi-line Definition
+
+Check that multi-line footnote definitions are handled[^multi].
+
+---
+
+[^1]: This is the first footnote. Simple single-line definition.
+[^note]: A footnote with a named label instead of a number.
+[^2]: Second footnote, referenced multiple times in the document.
+[^3]: Third footnote to verify sequential numbering.
+[^4]: Footnote content can also contain **bold**, *italic*, and `code`.
+[^5]: See: Markdown Extended Syntax, available at most Markdown parsers.
+[^multi]: This is the first line of a multi-line footnote.
+    This is a continuation line (indented by 4 spaces).
+    And another continuation line.


### PR DESCRIPTION
## Summary

Closes #60 — adds Pandoc-style footnote syntax (`[^label]` refs + `[^label]: content` definitions), matching GitHub / Obsidian / most extended markdown parsers. Bundled with update-dialog UX improvements (dismissed-version tracking + GitHub API notes fallback) that were needed during footnote QA.

## What's in

### Footnotes (#60)

**Parser** — lossless MD↔HTML roundtrip:
- Extracts `[^label]: text` defs from markdown (supports multi-line with 4-space continuation, multi-paragraph with blank-line separator)
- Converts `[^label]` refs to `<sup data-footnote-ref>` (skips matches inside inline code via regex alternation)
- Builds/parses `<section data-footnotes>` with URL-encoded JSON attr for lossless preservation through Tiptap

**Editor (Tiptap)**:
- `FootnoteRef` inline atom node — superscript number in text
- `FootnoteSection` block atom with Vue NodeView — editable bottom section
- ProseMirror plugin auto-renumbers refs by document order (idempotent, no infinite loop)
- `insertFootnote` command uses a single transaction with `tr.mapping.map()` so section pos stays valid after ref insert

**UX (Obsidian-like)**:
- Toolbar "Footnote" button inserts ref at cursor + opens edit popover above it
- Click on existing ref → same popover
- Hover on ref → tooltip with content preview
- Backlink arrow (↩) in each definition → scroll + 3s prominent pulse animation on the matching ref
- Click on definition → inline edit (Enter saves, Esc cancels, blur saves)
- "Footnotes" entry appended to Table of Contents (styled distinctly, scrolls directly to section)

**SRP refactor**:
- Footnote interactions extracted to `useFootnotes` composable
- `Editor.vue` lost ~130 lines of glue code
- Magic numbers centralized (`HIGHLIGHT_DURATION_MS`, `POPOVER_RETRY_MAX`, etc.)

**i18n**: en/pl/zh-CN — `footnote`, `insertFootnote`, `footnotes`, `addFootnote`, `deleteFootnotes`, `noFootnotes`, `footnoteContentPlaceholder`, `footnoteBacklink`.

### Update dialog improvements

- Dismissed version persisted in localStorage — closing with "Later" no longer nags on every app restart / HMR remount (fixed an actual reload loop during dev)
- GitHub Releases API fallback when Tauri updater body is empty — pulls from `/repos/Vesperino/MerMarkEditor/releases/tags/v{version}`. No more manual sync of `RELEASE_NOTES.md` into the dialog
- Collapsible "What's new" section in the dialog (default expanded, animated chevron)

## Tests

**54 new tests total, 507/507 passing, TS clean.**

- `footnote-utils.test.ts` — 26 tests (extract, convert, build, roundtrip, edge cases)
- `markdown-converter.test.ts` — +14 tests (footnote integration, roundtrip with formatting + inline code)
- `FootnoteNode.test.ts` — 9 tests (mount, render, backlink event dispatch, edit flow)
- `UpdateDialog.test.ts` — 10 tests (mount catches template compile errors, render, toggle, progress, error)
- `useAutoUpdate.test.ts` — 9 tests (dismissed-version logic, GitHub fallback, error handling)

No regressions against the existing 479 tests.

## Manual QA fixture

`test-footnotes.md` included — covers simple refs, named labels, multi-line defs, inline code with literal `[^1]` (should not convert), multi-reference of same label, etc.

## Known limitations (for follow-up)

- Footnote content edited in WYSIWYG renders as plain text (markdown source preserves `**bold**` etc. but visual view doesn't apply formatting)
- Popover doesn't clamp to viewport edges (could overflow on very small screens or when ref is at the very top)
- Label rename only via code view (WYSIWYG edits content only)
- No keyboard shortcut for insert (consistent with Mermaid)

## Test plan

- [x] Open `test-footnotes.md`, verify all footnotes render with superscript numbers
- [x] Hover over a superscript — tooltip shows definition text
- [x] Click a superscript — popover appears above it with content, edit + save with Enter
- [x] Click inside a paragraph, click toolbar Footnote button — ref inserted at cursor + popover opens
- [x] In the bottom section, click ↩ on a definition — view scrolls + the ref flashes visibly for ~3s
- [x] Click definition text — inline edit; Enter saves, Esc cancels
- [x] Toggle TOC (Ctrl+Shift+T) — "Footnotes" entry appears at the bottom, clicking it scrolls to the section
- [x] Switch to code view — footnotes render as `[^N]` and `[^N]: content`; edit roundtrip to visual works
- [x] Add/remove footnotes and re-open the file — order of refs matches numeric order
- [x] Close update dialog with "Later", restart app — dialog does not reappear for same version