### PR TITLE
feat: add resilient line numbers and macOS file-open handling (#61, #63)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::collections::{HashMap, BTreeSet};
+use std::path::Path;
 use tauri::{Manager, Emitter, WebviewUrl, WebviewWindowBuilder, RunEvent, WindowEvent};
 use serde::{Deserialize, Serialize};
 use font_kit::source::SystemSource;
@@ -13,6 +14,14 @@ pub struct OpenFilesRegistry(pub Mutex<HashMap<String, String>>);
 
 // Counter for unique window IDs
 static WINDOW_COUNTER: AtomicU32 = AtomicU32::new(1);
+
+fn is_supported_markdown_path(path: &str) -> bool {
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown"))
+        .unwrap_or(false)
+}
 
 // Payload for transferring tabs between windows
 #[derive(Clone, Serialize, Deserialize)]
@@ -208,7 +217,7 @@ pub fn run() {
 
                 if args.len() > 1 {
                     let file_path = &args[1];
-                    if file_path.ends_with(".md") || file_path.ends_with(".markdown") {
+                    if is_supported_markdown_path(file_path) {
                         let _ = window.emit("open-file", file_path.clone());
                     }
                 }
@@ -234,7 +243,7 @@ pub fn run() {
             let args: Vec<String> = std::env::args().collect();
             if args.len() > 1 {
                 let file_path = &args[1];
-                if file_path.ends_with(".md") || file_path.ends_with(".markdown") {
+                if is_supported_markdown_path(file_path) {
                     // Store the file path to be retrieved by frontend
                     let state = app.state::<OpenFileState>();
                     *state.0.lock().unwrap() = Some(file_path.clone());
@@ -252,6 +261,34 @@ pub fn run() {
         .expect("error while building tauri application")
         .run(|app, event| {
             match event {
+                #[cfg(target_os = "macos")]
+                RunEvent::Opened { urls } => {
+                    // macOS: Finder double-click on already-running app dispatches
+                    // NSApplicationDelegate application:openURLs: (no new process,
+                    // so single_instance plugin never fires). Handle it here. (#63)
+                    if let Some(window) = app.get_webview_window("main") {
+                        if window.is_minimized().unwrap_or(false) {
+                            let _ = window.unminimize();
+                        }
+                        if !window.is_visible().unwrap_or(true) {
+                            let _ = window.show();
+                        }
+                        let _ = window.set_focus();
+
+                        for url in urls {
+                            if let Ok(path) = url.to_file_path() {
+                                let path_str = path.to_string_lossy().to_string();
+                                if is_supported_markdown_path(&path_str) {
+                                    // Also store in state as fallback for cold-start
+                                    // race where frontend listener isn't mounted yet.
+                                    let state = app.state::<OpenFileState>();
+                                    *state.0.lock().unwrap() = Some(path_str.clone());
+                                    let _ = window.emit("open-file", path_str);
+                                }
+                            }
+                        }
+                    }
+                }
                 RunEvent::WindowEvent { label, event: WindowEvent::CloseRequested { api, .. }, .. } => {
                     // Get count of remaining windows
                     let windows = app.webview_windows();

--- a/src/__tests__/composables/useLineNumbers.test.ts
+++ b/src/__tests__/composables/useLineNumbers.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ref, nextTick } from 'vue';
+import { useLineNumbers } from '../../composables/useLineNumbers';
+
+type RectStub = { top: number; height: number; left: number; right: number; bottom: number; width: number };
+
+function stubChild(tag: string, rect: RectStub, opts: { text?: string; attrs?: Record<string, string>; rowCount?: number; lineHeight?: string } = {}): HTMLElement {
+  const el = document.createElement(tag);
+  if (opts.text) el.textContent = opts.text;
+  if (opts.attrs) for (const [k, v] of Object.entries(opts.attrs)) el.setAttribute(k, v);
+  if (opts.rowCount && tag.toLowerCase() === 'table') {
+    const tbody = document.createElement('tbody');
+    for (let i = 0; i < opts.rowCount; i++) tbody.appendChild(document.createElement('tr'));
+    el.appendChild(tbody);
+  }
+  el.getBoundingClientRect = () => ({ ...rect, x: rect.left, y: rect.top, toJSON: () => ({}) }) as DOMRect;
+
+  const cs = { lineHeight: opts.lineHeight ?? '20px', fontSize: '16px' } as CSSStyleDeclaration;
+  Object.defineProperty(el, '__mockCs', { value: cs });
+  return el;
+}
+
+function mountContainer(children: HTMLElement[], containerRect: RectStub, containerLineHeight = '20px'): HTMLElement {
+  const container = document.createElement('div');
+  for (const c of children) container.appendChild(c);
+  container.getBoundingClientRect = () => ({ ...containerRect, x: containerRect.left, y: containerRect.top, toJSON: () => ({}) }) as DOMRect;
+  const cs = { lineHeight: containerLineHeight, fontSize: '16px' } as CSSStyleDeclaration;
+  Object.defineProperty(container, '__mockCs', { value: cs });
+  document.body.appendChild(container);
+  return container;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((el) => {
+    const mocked = (el as unknown as { __mockCs?: CSSStyleDeclaration }).__mockCs;
+    return mocked ?? ({ lineHeight: '20px', fontSize: '16px' } as CSSStyleDeclaration);
+  });
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+});
+
+describe('useLineNumbers', () => {
+  it('returns empty when disabled', async () => {
+    const container = mountContainer([
+      stubChild('p', { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 }),
+    ], { top: 0, height: 100, left: 0, right: 100, bottom: 100, width: 100 });
+
+    const containerRef = ref<HTMLElement | null>(container);
+    const enabled = ref(false);
+    const { lines } = useLineNumbers({ containerRef, enabled });
+    await nextTick();
+
+    expect(lines.value).toEqual([]);
+  });
+
+  it('counts one line per single-line paragraph', async () => {
+    const p1 = stubChild('p', { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 });
+    const p2 = stubChild('p', { top: 20, height: 20, left: 0, right: 100, bottom: 40, width: 100 });
+    const container = mountContainer([p1, p2], { top: 0, height: 40, left: 0, right: 100, bottom: 40, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.map((l) => l.num)).toEqual([1, 2]);
+    expect(lines.value[0].top).toBe(0);
+    expect(lines.value[1].top).toBe(20);
+  });
+
+  it('splits wrapped block into multiple lines by height', async () => {
+    const wrapped = stubChild('p', { top: 0, height: 60, left: 0, right: 100, bottom: 60, width: 100 });
+    const container = mountContainer([wrapped], { top: 0, height: 60, left: 0, right: 100, bottom: 60, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(3);
+    expect(lines.value.map((l) => l.num)).toEqual([1, 2, 3]);
+  });
+
+  it('counts PRE by text-content newlines, not height', async () => {
+    const pre = stubChild('pre', { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 }, {
+      text: 'line1\nline2\nline3\nline4',
+    });
+    const container = mountContainer([pre], { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(4);
+  });
+
+  it('counts TABLE by tr count', async () => {
+    const table = stubChild('table', { top: 0, height: 120, left: 0, right: 100, bottom: 120, width: 100 }, { rowCount: 3 });
+    const container = mountContainer([table], { top: 0, height: 120, left: 0, right: 100, bottom: 120, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(3);
+  });
+
+  it('counts atomic mermaid block as one line', async () => {
+    const mermaid = stubChild('div', { top: 0, height: 300, left: 0, right: 100, bottom: 300, width: 100 }, { attrs: { 'data-type': 'mermaid' } });
+    const container = mountContainer([mermaid], { top: 0, height: 300, left: 0, right: 100, bottom: 300, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(1);
+  });
+
+  it('skips zero-height children', async () => {
+    const visible = stubChild('p', { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 });
+    const hidden = stubChild('p', { top: 0, height: 0, left: 0, right: 100, bottom: 0, width: 100 });
+    const container = mountContainer([visible, hidden], { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(1);
+  });
+});

--- a/src/__tests__/composables/useLineNumbers.test.ts
+++ b/src/__tests__/composables/useLineNumbers.test.ts
@@ -118,14 +118,24 @@ describe('useLineNumbers', () => {
     expect(lines.value.length).toBe(1);
   });
 
-  it('counts empty tall block as one line (ignores height/lineHeight ratio)', async () => {
+  it('counts small empty block as one line', async () => {
+    const emptySmall = stubChild('p', { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 });
+    const container = mountContainer([emptySmall], { top: 0, height: 20, left: 0, right: 100, bottom: 20, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(1);
+  });
+
+  it('suppresses empty structural block with oversize height', async () => {
     const emptyTall = stubChild('div', { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 });
     const container = mountContainer([emptyTall], { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 });
 
     const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
     await nextTick();
 
-    expect(lines.value.length).toBe(1);
+    expect(lines.value.length).toBe(0);
   });
 
   it('skips zero-height children', async () => {

--- a/src/__tests__/composables/useLineNumbers.test.ts
+++ b/src/__tests__/composables/useLineNumbers.test.ts
@@ -76,7 +76,7 @@ describe('useLineNumbers', () => {
   });
 
   it('splits wrapped block into multiple lines by height', async () => {
-    const wrapped = stubChild('p', { top: 0, height: 60, left: 0, right: 100, bottom: 60, width: 100 });
+    const wrapped = stubChild('p', { top: 0, height: 60, left: 0, right: 100, bottom: 60, width: 100 }, { text: 'long wrapped paragraph' });
     const container = mountContainer([wrapped], { top: 0, height: 60, left: 0, right: 100, bottom: 60, width: 100 });
 
     const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
@@ -111,6 +111,16 @@ describe('useLineNumbers', () => {
   it('counts atomic mermaid block as one line', async () => {
     const mermaid = stubChild('div', { top: 0, height: 300, left: 0, right: 100, bottom: 300, width: 100 }, { attrs: { 'data-type': 'mermaid' } });
     const container = mountContainer([mermaid], { top: 0, height: 300, left: 0, right: 100, bottom: 300, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value.length).toBe(1);
+  });
+
+  it('counts empty tall block as one line (ignores height/lineHeight ratio)', async () => {
+    const emptyTall = stubChild('div', { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 });
+    const container = mountContainer([emptyTall], { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 });
 
     const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
     await nextTick();

--- a/src/__tests__/composables/useLineNumbers.test.ts
+++ b/src/__tests__/composables/useLineNumbers.test.ts
@@ -31,6 +31,7 @@ function mountContainer(children: HTMLElement[], containerRect: RectStub, contai
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   document.body.innerHTML = '';
   (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
     observe() {}
@@ -86,6 +87,30 @@ describe('useLineNumbers', () => {
     expect(lines.value.map((l) => l.num)).toEqual([1, 2, 3]);
   });
 
+  it('normalizes small text-rect variance to the computed line height', async () => {
+    const wrapped = stubChild('p', { top: 0, height: 50, left: 0, right: 100, bottom: 50, width: 100 }, {
+      text: 'wrapped paragraph',
+      lineHeight: '24px',
+    });
+    const container = mountContainer([wrapped], { top: 0, height: 50, left: 0, right: 100, bottom: 50, width: 100 });
+
+    vi.spyOn(document, 'createRange').mockImplementation(() => ({
+      selectNodeContents() {},
+      getClientRects: () => ([
+        { top: 0, height: 25, left: 0, right: 100, bottom: 25, width: 100 },
+        { top: 24.5, height: 24.8, left: 0, right: 100, bottom: 49.3, width: 100 },
+      ].map((rect) => ({ ...rect, x: rect.left, y: rect.top, toJSON: () => ({}) }) as DOMRect)),
+      detach() {},
+    }) as unknown as Range);
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value).toHaveLength(2);
+    expect(lines.value.map((line) => line.height)).toEqual([24, 24]);
+    expect(lines.value.map((line) => Number(line.top.toFixed(2)))).toEqual([0.5, 24.5]);
+  });
+
   it('counts PRE by text-content newlines, not height', async () => {
     const pre = stubChild('pre', { top: 0, height: 200, left: 0, right: 100, bottom: 200, width: 100 }, {
       text: 'line1\nline2\nline3\nline4',
@@ -106,6 +131,38 @@ describe('useLineNumbers', () => {
     await nextTick();
 
     expect(lines.value.length).toBe(3);
+  });
+
+  it('counts table rows when TipTap wraps the table in tableWrapper', async () => {
+    const wrapper = stubChild('div', { top: 0, height: 160, left: 0, right: 100, bottom: 160, width: 100 }, {
+      attrs: { class: 'tableWrapper' },
+    });
+    const table = stubChild('table', { top: 0, height: 160, left: 0, right: 100, bottom: 160, width: 100 }, { rowCount: 4 });
+    wrapper.appendChild(table);
+
+    const rows = Array.from(table.querySelectorAll('tr')) as HTMLElement[];
+    rows.forEach((row, index) => {
+      const top = index * 40;
+      row.getBoundingClientRect = () => ({
+        top,
+        height: 40,
+        left: 0,
+        right: 100,
+        bottom: top + 40,
+        width: 100,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    });
+
+    const container = mountContainer([wrapper], { top: 0, height: 160, left: 0, right: 100, bottom: 160, width: 100 });
+
+    const { lines } = useLineNumbers({ containerRef: ref(container), enabled: ref(true) });
+    await nextTick();
+
+    expect(lines.value).toHaveLength(4);
+    expect(lines.value.map((line) => line.top)).toEqual([0, 40, 80, 120]);
   });
 
   it('counts atomic mermaid block as one line', async () => {

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -8,8 +8,9 @@ const { settings } = useSettings();
 
 const codeZoomStyle = computed(() => ({ zoom: zoomScale.value }));
 const wordWrap = computed(() => settings.value.codeWordWrap);
+const showLineNumbers = computed(() => settings.value.showLineNumbers);
 
-defineProps<{
+const props = defineProps<{
   modelValue: string;
 }>();
 
@@ -18,20 +19,41 @@ const emit = defineEmits<{
 }>();
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
+const gutterRef = ref<HTMLDivElement | null>(null);
 
-// Expose ref for parent to access
 defineExpose({
   textarea: textareaRef,
+});
+
+const lineCount = computed(() => {
+  const value = props.modelValue ?? '';
+  return Math.max(1, value.split('\n').length);
 });
 
 const handleInput = (event: Event) => {
   const target = event.target as HTMLTextAreaElement;
   emit('update:modelValue', target.value);
 };
+
+const handleScroll = (event: Event) => {
+  const target = event.target as HTMLTextAreaElement;
+  if (gutterRef.value) {
+    gutterRef.value.scrollTop = target.scrollTop;
+  }
+};
 </script>
 
 <template>
-  <div class="code-editor-container">
+  <div class="code-editor-container" :class="{ 'has-line-numbers': showLineNumbers }">
+    <div
+      v-if="showLineNumbers"
+      ref="gutterRef"
+      class="code-editor-gutter"
+      :style="codeZoomStyle"
+      aria-hidden="true"
+    >
+      <span v-for="n in lineCount" :key="n" class="code-editor-gutter-line">{{ n }}</span>
+    </div>
     <textarea
       id="code-editor-textarea"
       ref="textareaRef"
@@ -40,6 +62,7 @@ const handleInput = (event: Event) => {
       :style="codeZoomStyle"
       :value="modelValue"
       @input="handleInput"
+      @scroll="handleScroll"
       spellcheck="false"
       autocomplete="off"
       autocorrect="off"
@@ -56,6 +79,36 @@ const handleInput = (event: Event) => {
   overflow: hidden;
   background: var(--code-editor-container-bg);
   padding: 20px;
+}
+
+.code-editor-container.has-line-numbers {
+  flex-direction: row;
+  gap: 0;
+}
+
+.code-editor-gutter {
+  flex: 0 0 auto;
+  min-width: 3em;
+  padding: 24px 0.5em 24px 0.75em;
+  background: var(--code-editor-bg);
+  color: var(--text-secondary, #888);
+  opacity: 0.6;
+  font-family: var(--code-font-family, "Fira Code", "Consolas", "Monaco", monospace);
+  font-size: var(--code-font-size, 14px);
+  line-height: 1.6;
+  text-align: right;
+  user-select: none;
+  overflow: hidden;
+  border-radius: 8px 0 0 8px;
+  white-space: pre;
+}
+
+.code-editor-gutter-line {
+  display: block;
+}
+
+.code-editor-container.has-line-numbers .code-editor {
+  border-radius: 0 8px 8px 0;
 }
 
 .code-editor {

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { useEditorZoom } from '../composables/useEditorZoom';
 import { useSettings } from '../composables/useSettings';
 
@@ -21,6 +21,27 @@ const emit = defineEmits<{
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
 const gutterRef = ref<HTMLDivElement | null>(null);
 
+interface CodeGutterMetrics {
+  lineHeight: number;
+  paddingTop: number;
+  paddingBottom: number;
+}
+
+interface CodeGutterLine {
+  num: number;
+  top: number;
+  height: number;
+}
+
+const DEFAULT_GUTTER_METRICS: CodeGutterMetrics = {
+  lineHeight: 22.4,
+  paddingTop: 24,
+  paddingBottom: 24,
+};
+
+const gutterMetrics = ref<CodeGutterMetrics>({ ...DEFAULT_GUTTER_METRICS });
+let resizeObserver: ResizeObserver | null = null;
+
 defineExpose({
   textarea: textareaRef,
 });
@@ -28,6 +49,80 @@ defineExpose({
 const lineCount = computed(() => {
   const value = props.modelValue ?? '';
   return Math.max(1, value.split('\n').length);
+});
+
+const resolveTextareaMetrics = (textarea: HTMLTextAreaElement): CodeGutterMetrics => {
+  const computedStyle = window.getComputedStyle(textarea);
+  const fontSize = parseFloat(computedStyle.fontSize) || 14;
+  const parsedLineHeight = parseFloat(computedStyle.lineHeight);
+
+  return {
+    lineHeight: computedStyle.lineHeight === 'normal' || Number.isNaN(parsedLineHeight)
+      ? fontSize * 1.2
+      : parsedLineHeight,
+    paddingTop: parseFloat(computedStyle.paddingTop) || 0,
+    paddingBottom: parseFloat(computedStyle.paddingBottom) || 0,
+  };
+};
+
+const syncGutterMetrics = () => {
+  const textarea = textareaRef.value;
+  if (!textarea) {
+    gutterMetrics.value = { ...DEFAULT_GUTTER_METRICS };
+    return;
+  }
+
+  gutterMetrics.value = resolveTextareaMetrics(textarea);
+
+  if (gutterRef.value) {
+    gutterRef.value.scrollTop = textarea.scrollTop;
+  }
+};
+
+const scheduleGutterSync = () => {
+  requestAnimationFrame(syncGutterMetrics);
+};
+
+const gutterLines = computed<CodeGutterLine[]>(() => {
+  const { lineHeight, paddingTop } = gutterMetrics.value;
+  return Array.from({ length: lineCount.value }, (_, index) => ({
+    num: index + 1,
+    top: paddingTop + index * lineHeight,
+    height: lineHeight,
+  }));
+});
+
+const gutterContentHeight = computed(() => {
+  const { lineHeight, paddingTop, paddingBottom } = gutterMetrics.value;
+  return paddingTop + paddingBottom + lineCount.value * lineHeight;
+});
+
+watch(textareaRef, (textarea, previous) => {
+  if (resizeObserver && previous) {
+    resizeObserver.unobserve(previous);
+  }
+
+  if (!textarea) return;
+
+  if (!resizeObserver) {
+    resizeObserver = new ResizeObserver(syncGutterMetrics);
+  }
+
+  resizeObserver.observe(textarea);
+  scheduleGutterSync();
+}, { immediate: true });
+
+watch([
+  () => props.modelValue,
+  wordWrap,
+  showLineNumbers,
+  zoomScale,
+  () => settings.value.codeFontFamily,
+], scheduleGutterSync);
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  resizeObserver = null;
 });
 
 const handleInput = (event: Event) => {
@@ -52,7 +147,17 @@ const handleScroll = (event: Event) => {
       :style="codeZoomStyle"
       aria-hidden="true"
     >
-      <span v-for="n in lineCount" :key="n" class="code-editor-gutter-line">{{ n }}</span>
+      <div class="code-editor-gutter-content" :style="{ height: `${gutterContentHeight}px` }">
+        <span
+          v-for="line in gutterLines"
+          :key="line.num"
+          class="code-editor-gutter-line"
+          :style="{
+            top: `${line.top}px`,
+            height: `${line.height}px`,
+          }"
+        >{{ line.num }}</span>
+      </div>
     </div>
     <textarea
       id="code-editor-textarea"
@@ -89,22 +194,34 @@ const handleScroll = (event: Event) => {
 .code-editor-gutter {
   flex: 0 0 auto;
   min-width: 3em;
-  padding: 24px 0.5em 24px 0.75em;
+  box-sizing: border-box;
+  padding: 0 0.5em 0 0.75em;
   background: var(--code-editor-bg);
   color: var(--text-secondary, #888);
   opacity: 0.6;
   font-family: var(--code-font-family, "Fira Code", "Consolas", "Monaco", monospace);
   font-size: var(--code-font-size, 14px);
-  line-height: 1.6;
+  line-height: 1;
   text-align: right;
   user-select: none;
   overflow: hidden;
   border-radius: 8px 0 0 8px;
-  white-space: pre;
+  position: relative;
+}
+
+.code-editor-gutter-content {
+  position: relative;
+  min-height: 100%;
 }
 
 .code-editor-gutter-line {
-  display: block;
+  position: absolute;
+  right: 0.5em;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  line-height: 1;
 }
 
 .code-editor-container.has-line-numbers .code-editor {

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -48,14 +48,16 @@ import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { Placeholder } from "@tiptap/extension-placeholder";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import { common, createLowlight } from "lowlight";
-import { watch, ref, nextTick, computed } from "vue";
+import { watch, ref, nextTick, computed, watchEffect } from "vue";
 import { Extension, Node, mergeAttributes, textblockTypeInputRule } from "@tiptap/core";
 import { useEditorZoom } from "../composables/useEditorZoom";
 import { useSettings } from "../composables/useSettings";
 import { useFootnotes } from "../composables/useFootnotes";
+import { useLineNumbers } from "../composables/useLineNumbers";
 import { resolveEditorImages, getDirectoryFromFilePath } from "../utils/image-resolver";
 import TableContextMenu from "./TableContextMenu.vue";
 import ImagePreview from "./ImagePreview.vue";
+import EditorGutter from "./EditorGutter.vue";
 
 // Guards against false hasChanges during programmatic content updates.
 // Starts at 1 to cover initial editor creation; released after 300ms.
@@ -571,12 +573,30 @@ watch(() => appSettings.value.spellcheck, (newVal) => {
   }
 });
 
+const proseMirrorRef = ref<HTMLElement | null>(null);
+const showLineNumbersRef = computed(() => appSettings.value.showLineNumbers);
+const { lines: lineNumberEntries } = useLineNumbers({
+  containerRef: proseMirrorRef,
+  enabled: showLineNumbersRef,
+});
+
+watchEffect(() => {
+  proseMirrorRef.value = (editor.value?.view?.dom as HTMLElement | undefined) ?? null;
+});
+
 defineExpose({ editor });
 </script>
 
 <template>
   <div class="editor-container" ref="editorContainerRef" @click="handleEditorClick" @contextmenu="handleContextMenu" @mouseover="footnotes.handleMouseOver" @mouseout="footnotes.handleMouseOut">
-    <EditorContent :editor="editor" class="editor-content" :style="editorZoomStyle" />
+    <div
+      class="editor-content-wrapper"
+      :class="{ 'has-line-numbers': appSettings.showLineNumbers }"
+      :style="editorZoomStyle"
+    >
+      <EditorGutter v-if="appSettings.showLineNumbers" :lines="lineNumberEntries" />
+      <EditorContent :editor="editor" class="editor-content" />
+    </div>
     <TableContextMenu
       v-if="showContextMenu"
       :x="contextMenuX"
@@ -629,10 +649,22 @@ defineExpose({ editor });
   background: var(--editor-container-bg);
 }
 
-.editor-content {
-  background: var(--editor-content-bg);
+.editor-content-wrapper {
+  position: relative;
   max-width: 900px;
   margin: 20px auto;
+}
+
+.editor-content-wrapper.has-line-numbers {
+  --editor-gutter-width: 3.5em;
+}
+
+.editor-content-wrapper.has-line-numbers .editor-content {
+  padding-left: calc(80px + var(--editor-gutter-width));
+}
+
+.editor-content {
+  background: var(--editor-content-bg);
   padding: 60px 80px;
   min-height: calc(100vh - 180px);
   box-shadow: var(--shadow-sm);

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -574,9 +574,11 @@ watch(() => appSettings.value.spellcheck, (newVal) => {
 });
 
 const proseMirrorRef = ref<HTMLElement | null>(null);
+const contentWrapperRef = ref<HTMLElement | null>(null);
 const showLineNumbersRef = computed(() => appSettings.value.showLineNumbers);
 const { lines: lineNumberEntries } = useLineNumbers({
   containerRef: proseMirrorRef,
+  anchorRef: contentWrapperRef,
   enabled: showLineNumbersRef,
 });
 
@@ -590,6 +592,7 @@ defineExpose({ editor });
 <template>
   <div class="editor-container" ref="editorContainerRef" @click="handleEditorClick" @contextmenu="handleContextMenu" @mouseover="footnotes.handleMouseOver" @mouseout="footnotes.handleMouseOut">
     <div
+      ref="contentWrapperRef"
       class="editor-content-wrapper"
       :class="{ 'has-line-numbers': appSettings.showLineNumbers }"
       :style="editorZoomStyle"

--- a/src/components/EditorGutter.vue
+++ b/src/components/EditorGutter.vue
@@ -13,7 +13,7 @@ defineProps<{
       :key="line.num"
       class="editor-gutter-line"
       :style="{
-        top: `calc(var(--editor-content-padding-top, 60px) + ${line.top}px)`,
+        top: `${line.top}px`,
         height: `${line.height}px`,
       }"
     >{{ line.num }}</span>

--- a/src/components/EditorGutter.vue
+++ b/src/components/EditorGutter.vue
@@ -12,7 +12,10 @@ defineProps<{
       v-for="line in lines"
       :key="line.num"
       class="editor-gutter-line"
-      :style="{ top: `calc(var(--editor-content-padding-top, 60px) + ${line.top}px)` }"
+      :style="{
+        top: `calc(var(--editor-content-padding-top, 60px) + ${line.top}px)`,
+        height: `${line.height}px`,
+      }"
     >{{ line.num }}</span>
   </div>
 </template>
@@ -35,7 +38,10 @@ defineProps<{
 .editor-gutter-line {
   position: absolute;
   right: 0.5em;
-  text-align: right;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   line-height: 1;
 }
 </style>

--- a/src/components/EditorGutter.vue
+++ b/src/components/EditorGutter.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { LineEntry } from '../composables/useLineNumbers';
+
+defineProps<{
+  lines: LineEntry[];
+}>();
+</script>
+
+<template>
+  <div class="editor-gutter" aria-hidden="true">
+    <span
+      v-for="line in lines"
+      :key="line.num"
+      class="editor-gutter-line"
+      :style="{ top: `calc(var(--editor-content-padding-top, 60px) + ${line.top}px)` }"
+    >{{ line.num }}</span>
+  </div>
+</template>
+
+<style scoped>
+.editor-gutter {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(80px + var(--editor-gutter-width, 3.5em));
+  height: 100%;
+  pointer-events: none;
+  user-select: none;
+  font-family: var(--code-font-family, monospace);
+  font-size: 0.85em;
+  color: var(--text-secondary, #888);
+  opacity: 0.7;
+}
+
+.editor-gutter-line {
+  position: absolute;
+  right: 0.5em;
+  text-align: right;
+  line-height: 1;
+}
+</style>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -17,6 +17,7 @@ const {
   setEditorLineHeight,
   setSpellcheck,
   setExpandTabs,
+  setShowLineNumbers,
   toggleCodeWordWrap,
 } = useSettings();
 
@@ -486,6 +487,28 @@ onUnmounted(() => {
                     class="toggle-option"
                     :class="{ active: settings.spellcheck }"
                     @click="setSpellcheck(true)"
+                  >
+                    {{ t.on }}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div class="setting-row">
+              <label class="setting-label">{{ t.showLineNumbers }}</label>
+              <div class="setting-control">
+                <div class="toggle-group">
+                  <button
+                    class="toggle-option"
+                    :class="{ active: !settings.showLineNumbers }"
+                    @click="setShowLineNumbers(false)"
+                  >
+                    {{ t.off }}
+                  </button>
+                  <button
+                    class="toggle-option"
+                    :class="{ active: settings.showLineNumbers }"
+                    @click="setShowLineNumbers(true)"
                   >
                     {{ t.on }}
                   </button>

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -118,16 +118,16 @@ function getLinesForBlock(el: HTMLElement, rect: DOMRect): LineRect[] {
     return getTableRowRects(el, rect);
   }
 
-  if (el.tagName === 'PRE') {
-    return getPreLineRects(el, rect);
-  }
-
   if ((el.textContent ?? '').trim() === '') {
     return [{ top: rect.top, height: rect.height }];
   }
 
   const textRects = getTextLineRects(el);
   if (textRects.length > 0) return textRects;
+
+  if (el.tagName === 'PRE') {
+    return getPreLineRects(el, rect);
+  }
 
   return fallbackLineRects(el, rect);
 }

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -19,6 +19,7 @@ interface LineRect {
 
 const MIN_LINE_HEIGHT_PX = 4;
 const MERGE_OVERLAP_FRACTION = 0.35;
+const LINE_HEIGHT_SNAP_FRACTION = 0.45;
 const MAX_EMPTY_LINE_HEIGHT_PX = 60;
 
 export function useLineNumbers({ containerRef, enabled, anchorRef }: UseLineNumbersOptions) {
@@ -115,8 +116,9 @@ function getLinesForBlock(el: HTMLElement, rect: DOMRect): LineRect[] {
     return [{ top: rect.top, height: rect.height }];
   }
 
-  if (el.tagName === 'TABLE') {
-    return getTableRowRects(el, rect);
+  const table = resolveTableElement(el);
+  if (table) {
+    return getTableRowRects(table, table.getBoundingClientRect());
   }
 
   if ((el.textContent ?? '').trim() === '') {
@@ -148,6 +150,14 @@ function getTableRowRects(table: HTMLElement, tableRect: DOMRect): LineRect[] {
   return rows.map((_, i) => ({ top: tableRect.top + i * step, height: step }));
 }
 
+function resolveTableElement(el: HTMLElement): HTMLElement | null {
+  if (el.tagName === 'TABLE') return el;
+  if (el.classList.contains('tableWrapper')) {
+    return el.querySelector(':scope > table');
+  }
+  return null;
+}
+
 function getPreLineRects(pre: HTMLElement, rect: DOMRect): LineRect[] {
   const textLines = Math.max(1, (pre.textContent ?? '').split('\n').length);
   const step = rect.height / textLines;
@@ -162,7 +172,7 @@ function getTextLineRects(el: HTMLElement): LineRect[] {
   if (!el.firstChild || typeof document.createRange !== 'function') return [];
   const collected: DOMRect[] = [];
   collectInlineRects(el, collected);
-  return mergeSameRow(collected);
+  return normalizeTextLineRects(mergeSameRow(collected), resolveLineHeightPx(el));
 }
 
 function collectInlineRects(el: HTMLElement, out: DOMRect[]): void {
@@ -227,6 +237,38 @@ function mergeSameRow(rects: DOMRect[]): LineRect[] {
     merged.push({ top, bottom });
   }
   return merged.map((m) => ({ top: m.top, height: m.bottom - m.top }));
+}
+
+function normalizeTextLineRects(rects: LineRect[], lineHeightPx: number): LineRect[] {
+  if (rects.length === 0 || lineHeightPx < MIN_LINE_HEIGHT_PX) return rects;
+
+  const tolerance = lineHeightPx * LINE_HEIGHT_SNAP_FRACTION;
+  const normalized: LineRect[] = [];
+  let baselineTop: number | null = null;
+
+  for (let index = 0; index < rects.length; index++) {
+    const rect = rects[index];
+    const shouldSnapHeight = Math.abs(rect.height - lineHeightPx) <= tolerance;
+    const height = shouldSnapHeight ? lineHeightPx : rect.height;
+    let top = rect.top;
+
+    if (shouldSnapHeight) {
+      top += (rect.height - height) / 2;
+    }
+
+    if (baselineTop === null) {
+      baselineTop = top;
+    } else {
+      const expectedTop = baselineTop + index * lineHeightPx;
+      if (Math.abs(top - expectedTop) <= tolerance) {
+        top = expectedTop;
+      }
+    }
+
+    normalized.push({ top, height });
+  }
+
+  return normalized;
 }
 
 function fallbackLineRects(el: HTMLElement, rect: DOMRect): LineRect[] {

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -69,6 +69,8 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
       return Math.max(1, el.querySelectorAll('tr').length);
     }
 
+    if ((el.textContent ?? '').trim() === '') return 1;
+
     const lineHeightPx = resolveLineHeightPx(el);
     if (lineHeightPx < MIN_LINE_HEIGHT_PX) return 1;
     return Math.max(1, Math.round(height / lineHeightPx));

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -1,0 +1,140 @@
+import { ref, watch, onBeforeUnmount, type Ref } from 'vue';
+
+export interface LineEntry {
+  top: number;
+  num: number;
+}
+
+interface UseLineNumbersOptions {
+  containerRef: Ref<HTMLElement | null>;
+  enabled: Ref<boolean>;
+}
+
+const MIN_LINE_HEIGHT_PX = 4;
+
+export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions) {
+  const lines = ref<LineEntry[]>([]);
+
+  let resizeObserver: ResizeObserver | null = null;
+  let mutationObserver: MutationObserver | null = null;
+  let rafHandle: number | null = null;
+
+  const scheduleRecompute = () => {
+    if (rafHandle !== null) return;
+    rafHandle = requestAnimationFrame(() => {
+      rafHandle = null;
+      recompute();
+    });
+  };
+
+  const recompute = () => {
+    const container = containerRef.value;
+    if (!container) {
+      lines.value = [];
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const entries: LineEntry[] = [];
+    let counter = 1;
+
+    for (const child of Array.from(container.children) as HTMLElement[]) {
+      const rect = child.getBoundingClientRect();
+      if (rect.height === 0) continue;
+
+      const topInContainer = rect.top - containerRect.top;
+      const lineCount = countLinesForBlock(child, rect.height);
+      const step = lineCount > 0 ? rect.height / lineCount : rect.height;
+
+      for (let i = 0; i < lineCount; i++) {
+        entries.push({
+          top: topInContainer + i * step,
+          num: counter++,
+        });
+      }
+    }
+
+    lines.value = entries;
+  };
+
+  const countLinesForBlock = (el: HTMLElement, height: number): number => {
+    if (isAtomicBlock(el)) return 1;
+
+    if (el.tagName === 'PRE') {
+      const textLines = (el.textContent ?? '').split('\n').length;
+      return Math.max(1, textLines);
+    }
+
+    if (el.tagName === 'TABLE') {
+      return Math.max(1, el.querySelectorAll('tr').length);
+    }
+
+    const lineHeightPx = resolveLineHeightPx(el);
+    if (lineHeightPx < MIN_LINE_HEIGHT_PX) return 1;
+    return Math.max(1, Math.round(height / lineHeightPx));
+  };
+
+  const attach = () => {
+    const container = containerRef.value;
+    if (!container) return;
+
+    resizeObserver = new ResizeObserver(scheduleRecompute);
+    resizeObserver.observe(container);
+    for (const child of Array.from(container.children)) {
+      resizeObserver.observe(child);
+    }
+
+    mutationObserver = new MutationObserver(() => {
+      if (resizeObserver) {
+        for (const child of Array.from(container.children)) {
+          resizeObserver.observe(child);
+        }
+      }
+      scheduleRecompute();
+    });
+    mutationObserver.observe(container, { childList: true, subtree: false, characterData: true });
+
+    scheduleRecompute();
+  };
+
+  const detach = () => {
+    resizeObserver?.disconnect();
+    mutationObserver?.disconnect();
+    resizeObserver = null;
+    mutationObserver = null;
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+    lines.value = [];
+  };
+
+  watch([containerRef, enabled], ([container, isEnabled]) => {
+    detach();
+    if (isEnabled && container) attach();
+  }, { immediate: true });
+
+  onBeforeUnmount(detach);
+
+  return { lines, recompute: scheduleRecompute };
+}
+
+function isAtomicBlock(el: HTMLElement): boolean {
+  const tag = el.tagName;
+  if (tag === 'IMG' || tag === 'HR') return true;
+  if (el.getAttribute('data-type') === 'mermaid') return true;
+  if (el.querySelector(':scope > img.editor-image')) return true;
+  return false;
+}
+
+function resolveLineHeightPx(el: HTMLElement): number {
+  const computed = window.getComputedStyle(el);
+  const raw = computed.lineHeight;
+  const parsed = parseFloat(raw);
+  if (!Number.isNaN(parsed) && raw.endsWith('px')) return parsed;
+
+  const fontSize = parseFloat(computed.fontSize) || 16;
+  if (raw === 'normal') return fontSize * 1.2;
+  if (!Number.isNaN(parsed)) return parsed * fontSize;
+  return fontSize * 1.6;
+}

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -18,7 +18,8 @@ interface LineRect {
 }
 
 const MIN_LINE_HEIGHT_PX = 4;
-const OVERLAP_TOLERANCE_PX = 2;
+const MERGE_OVERLAP_FRACTION = 0.35;
+const MAX_EMPTY_LINE_HEIGHT_PX = 60;
 
 export function useLineNumbers({ containerRef, enabled, anchorRef }: UseLineNumbersOptions) {
   const lines = ref<LineEntry[]>([]);
@@ -119,6 +120,7 @@ function getLinesForBlock(el: HTMLElement, rect: DOMRect): LineRect[] {
   }
 
   if ((el.textContent ?? '').trim() === '') {
+    if (rect.height > MAX_EMPTY_LINE_HEIGHT_PX) return [];
     return [{ top: rect.top, height: rect.height }];
   }
 
@@ -213,12 +215,16 @@ function mergeSameRow(rects: DOMRect[]): LineRect[] {
     const top = r.top;
     const bottom = r.top + r.height;
     const last = merged[merged.length - 1];
-    if (last && top < last.bottom - OVERLAP_TOLERANCE_PX) {
-      last.top = Math.min(last.top, top);
-      last.bottom = Math.max(last.bottom, bottom);
-    } else {
-      merged.push({ top, bottom });
+    if (last) {
+      const overlap = Math.min(last.bottom, bottom) - Math.max(last.top, top);
+      const minHeight = Math.min(last.bottom - last.top, bottom - top);
+      if (minHeight > 0 && overlap > minHeight * MERGE_OVERLAP_FRACTION) {
+        last.top = Math.min(last.top, top);
+        last.bottom = Math.max(last.bottom, bottom);
+        continue;
+      }
     }
+    merged.push({ top, bottom });
   }
   return merged.map((m) => ({ top: m.top, height: m.bottom - m.top }));
 }

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -9,6 +9,7 @@ export interface LineEntry {
 interface UseLineNumbersOptions {
   containerRef: Ref<HTMLElement | null>;
   enabled: Ref<boolean>;
+  anchorRef?: Ref<HTMLElement | null>;
 }
 
 interface LineRect {
@@ -17,9 +18,9 @@ interface LineRect {
 }
 
 const MIN_LINE_HEIGHT_PX = 4;
-const SAME_ROW_THRESHOLD_PX = 2;
+const OVERLAP_TOLERANCE_PX = 2;
 
-export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions) {
+export function useLineNumbers({ containerRef, enabled, anchorRef }: UseLineNumbersOptions) {
   const lines = ref<LineEntry[]>([]);
 
   let resizeObserver: ResizeObserver | null = null;
@@ -41,7 +42,8 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
       return;
     }
 
-    const containerRect = container.getBoundingClientRect();
+    const anchor = anchorRef?.value ?? container;
+    const anchorRect = anchor.getBoundingClientRect();
     const entries: LineEntry[] = [];
     let counter = 1;
 
@@ -52,7 +54,7 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
       const lineRects = getLinesForBlock(child, rect);
       for (const lr of lineRects) {
         entries.push({
-          top: lr.top - containerRect.top,
+          top: lr.top - anchorRect.top,
           num: counter++,
           height: lr.height,
         });
@@ -156,30 +158,69 @@ function getPreLineRects(pre: HTMLElement, rect: DOMRect): LineRect[] {
 
 function getTextLineRects(el: HTMLElement): LineRect[] {
   if (!el.firstChild || typeof document.createRange !== 'function') return [];
-  try {
-    const range = document.createRange();
-    range.selectNodeContents(el);
-    const raw = Array.from(range.getClientRects()).filter((r) => r.height > 0 && r.width > 0);
-    range.detach?.();
-    return mergeSameRow(raw);
-  } catch {
-    return [];
+  const collected: DOMRect[] = [];
+  collectInlineRects(el, collected);
+  return mergeSameRow(collected);
+}
+
+function collectInlineRects(el: HTMLElement, out: DOMRect[]): void {
+  if (!el.firstChild) return;
+
+  if (!hasBlockChild(el)) {
+    try {
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      const rects = Array.from(range.getClientRects()).filter((r) => r.height > 0 && r.width > 0);
+      out.push(...rects);
+      range.detach?.();
+    } catch {
+      /* ignore */
+    }
+    return;
   }
+
+  for (const child of Array.from(el.children) as HTMLElement[]) {
+    const rect = child.getBoundingClientRect();
+    if (rect.height === 0 || rect.width === 0) continue;
+    collectInlineRects(child, out);
+  }
+}
+
+function hasBlockChild(el: HTMLElement): boolean {
+  for (const child of Array.from(el.children) as HTMLElement[]) {
+    const d = window.getComputedStyle(child).display;
+    if (
+      d === 'block' ||
+      d === 'flex' ||
+      d === 'grid' ||
+      d === 'list-item' ||
+      d === 'table' ||
+      d === 'table-row' ||
+      d === 'table-row-group' ||
+      d === 'flow-root'
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function mergeSameRow(rects: DOMRect[]): LineRect[] {
   if (rects.length === 0) return [];
   const sorted = [...rects].sort((a, b) => a.top - b.top);
-  const merged: LineRect[] = [];
+  const merged: { top: number; bottom: number }[] = [];
   for (const r of sorted) {
+    const top = r.top;
+    const bottom = r.top + r.height;
     const last = merged[merged.length - 1];
-    if (last && Math.abs(last.top - r.top) < SAME_ROW_THRESHOLD_PX) {
-      if (r.height > last.height) last.height = r.height;
+    if (last && top < last.bottom - OVERLAP_TOLERANCE_PX) {
+      last.top = Math.min(last.top, top);
+      last.bottom = Math.max(last.bottom, bottom);
     } else {
-      merged.push({ top: r.top, height: r.height });
+      merged.push({ top, bottom });
     }
   }
-  return merged;
+  return merged.map((m) => ({ top: m.top, height: m.bottom - m.top }));
 }
 
 function fallbackLineRects(el: HTMLElement, rect: DOMRect): LineRect[] {

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -3,6 +3,7 @@ import { ref, watch, onBeforeUnmount, type Ref } from 'vue';
 export interface LineEntry {
   top: number;
   num: number;
+  height: number;
 }
 
 interface UseLineNumbersOptions {
@@ -50,6 +51,7 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
         entries.push({
           top: topInContainer + i * step,
           num: counter++,
+          height: step,
         });
       }
     }

--- a/src/composables/useLineNumbers.ts
+++ b/src/composables/useLineNumbers.ts
@@ -11,7 +11,13 @@ interface UseLineNumbersOptions {
   enabled: Ref<boolean>;
 }
 
+interface LineRect {
+  top: number;
+  height: number;
+}
+
 const MIN_LINE_HEIGHT_PX = 4;
+const SAME_ROW_THRESHOLD_PX = 2;
 
 export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions) {
   const lines = ref<LineEntry[]>([]);
@@ -43,39 +49,17 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
       const rect = child.getBoundingClientRect();
       if (rect.height === 0) continue;
 
-      const topInContainer = rect.top - containerRect.top;
-      const lineCount = countLinesForBlock(child, rect.height);
-      const step = lineCount > 0 ? rect.height / lineCount : rect.height;
-
-      for (let i = 0; i < lineCount; i++) {
+      const lineRects = getLinesForBlock(child, rect);
+      for (const lr of lineRects) {
         entries.push({
-          top: topInContainer + i * step,
+          top: lr.top - containerRect.top,
           num: counter++,
-          height: step,
+          height: lr.height,
         });
       }
     }
 
     lines.value = entries;
-  };
-
-  const countLinesForBlock = (el: HTMLElement, height: number): number => {
-    if (isAtomicBlock(el)) return 1;
-
-    if (el.tagName === 'PRE') {
-      const textLines = (el.textContent ?? '').split('\n').length;
-      return Math.max(1, textLines);
-    }
-
-    if (el.tagName === 'TABLE') {
-      return Math.max(1, el.querySelectorAll('tr').length);
-    }
-
-    if ((el.textContent ?? '').trim() === '') return 1;
-
-    const lineHeightPx = resolveLineHeightPx(el);
-    if (lineHeightPx < MIN_LINE_HEIGHT_PX) return 1;
-    return Math.max(1, Math.round(height / lineHeightPx));
   };
 
   const attach = () => {
@@ -121,6 +105,95 @@ export function useLineNumbers({ containerRef, enabled }: UseLineNumbersOptions)
   onBeforeUnmount(detach);
 
   return { lines, recompute: scheduleRecompute };
+}
+
+function getLinesForBlock(el: HTMLElement, rect: DOMRect): LineRect[] {
+  if (isAtomicBlock(el)) {
+    return [{ top: rect.top, height: rect.height }];
+  }
+
+  if (el.tagName === 'TABLE') {
+    return getTableRowRects(el, rect);
+  }
+
+  if (el.tagName === 'PRE') {
+    return getPreLineRects(el, rect);
+  }
+
+  if ((el.textContent ?? '').trim() === '') {
+    return [{ top: rect.top, height: rect.height }];
+  }
+
+  const textRects = getTextLineRects(el);
+  if (textRects.length > 0) return textRects;
+
+  return fallbackLineRects(el, rect);
+}
+
+function getTableRowRects(table: HTMLElement, tableRect: DOMRect): LineRect[] {
+  const rows = Array.from(table.querySelectorAll('tr')) as HTMLElement[];
+  if (rows.length === 0) return [{ top: tableRect.top, height: tableRect.height }];
+
+  const measured = rows
+    .map((tr) => tr.getBoundingClientRect())
+    .filter((r) => r.height > 0)
+    .map((r) => ({ top: r.top, height: r.height }));
+  if (measured.length === rows.length) return measured;
+
+  const step = tableRect.height / rows.length;
+  return rows.map((_, i) => ({ top: tableRect.top + i * step, height: step }));
+}
+
+function getPreLineRects(pre: HTMLElement, rect: DOMRect): LineRect[] {
+  const textLines = Math.max(1, (pre.textContent ?? '').split('\n').length);
+  const step = rect.height / textLines;
+  const out: LineRect[] = [];
+  for (let i = 0; i < textLines; i++) {
+    out.push({ top: rect.top + i * step, height: step });
+  }
+  return out;
+}
+
+function getTextLineRects(el: HTMLElement): LineRect[] {
+  if (!el.firstChild || typeof document.createRange !== 'function') return [];
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const raw = Array.from(range.getClientRects()).filter((r) => r.height > 0 && r.width > 0);
+    range.detach?.();
+    return mergeSameRow(raw);
+  } catch {
+    return [];
+  }
+}
+
+function mergeSameRow(rects: DOMRect[]): LineRect[] {
+  if (rects.length === 0) return [];
+  const sorted = [...rects].sort((a, b) => a.top - b.top);
+  const merged: LineRect[] = [];
+  for (const r of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && Math.abs(last.top - r.top) < SAME_ROW_THRESHOLD_PX) {
+      if (r.height > last.height) last.height = r.height;
+    } else {
+      merged.push({ top: r.top, height: r.height });
+    }
+  }
+  return merged;
+}
+
+function fallbackLineRects(el: HTMLElement, rect: DOMRect): LineRect[] {
+  const lineHeightPx = resolveLineHeightPx(el);
+  if (lineHeightPx < MIN_LINE_HEIGHT_PX) {
+    return [{ top: rect.top, height: rect.height }];
+  }
+  const count = Math.max(1, Math.round(rect.height / lineHeightPx));
+  const step = rect.height / count;
+  const out: LineRect[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({ top: rect.top + i * step, height: step });
+  }
+  return out;
 }
 
 function isAtomicBlock(el: HTMLElement): boolean {

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -51,6 +51,7 @@ export interface AppSettings {
   editorLineHeight: number;
   spellcheck: boolean;
   expandTabs: boolean;
+  showLineNumbers: boolean;
 }
 
 const STORAGE_KEY = 'mermark-settings';
@@ -116,6 +117,7 @@ function getDefaultSettings(): AppSettings {
     editorLineHeight: 1.6,
     spellcheck: false,
     expandTabs: false,
+    showLineNumbers: false,
   };
 }
 
@@ -193,6 +195,14 @@ export function useSettings() {
     settings.value.expandTabs = value;
   };
 
+  const setShowLineNumbers = (value: boolean) => {
+    settings.value.showLineNumbers = value;
+  };
+
+  const toggleShowLineNumbers = () => {
+    settings.value.showLineNumbers = !settings.value.showLineNumbers;
+  };
+
   return {
     settings,
     setAutoSave,
@@ -208,6 +218,8 @@ export function useSettings() {
     setEditorLineHeight,
     setSpellcheck,
     setExpandTabs,
+    setShowLineNumbers,
+    toggleShowLineNumbers,
   };
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -164,6 +164,7 @@ export interface Translations {
   codeFont: string;
   lineHeight: string;
   spellcheck: string;
+  showLineNumbers: string;
   expandTabs: string;
   appearance: string;
   editor: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -158,6 +158,7 @@ const en: Translations = {
   codeFont: 'Code font',
   lineHeight: 'Line height',
   spellcheck: 'Spellcheck',
+  showLineNumbers: 'Line numbers',
   expandTabs: 'Expand tabs to fit name',
   appearance: 'Appearance',
   editor: 'Editor',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -158,6 +158,7 @@ const pl: Translations = {
   codeFont: 'Czcionka kodu',
   lineHeight: 'Wysokość linii',
   spellcheck: 'Sprawdzanie pisowni',
+  showLineNumbers: 'Numery linii',
   expandTabs: 'Rozszerz karty do pełnej nazwy',
   appearance: 'Wygląd',
   editor: 'Edytor',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -158,6 +158,7 @@ const zhCN: Translations = {
   codeFont: '代码字体',
   lineHeight: '行高',
   spellcheck: '拼写检查',
+  showLineNumbers: '行号',
   expandTabs: '展开标签页以显示完整名称',
   appearance: '外观',
   editor: '编辑器',


### PR DESCRIPTION
﻿## Summary
- add toggleable line numbers for the visual editor and code view
- keep line numbers aligned across wrapped text, headings, empty blocks, and TipTap table wrappers, with extra hardening for Tauri/WebView2 layout variance
- handle macOS Finder open events for an already-running app and accept case-insensitive `.md` / `.markdown` file extensions

## Issues
Closes #61
Closes #63

## Testing
- `pnpm exec vitest run src/__tests__/composables/useLineNumbers.test.ts src/__tests__/composables/useCodeView.test.ts`
- `pnpm build`

## Notes
- `cargo` was not available in this environment, so I could not run a Rust-side build/check here.
