### PR TITLE
fix(ai): detect Claude/Codex CLI on macOS and Linux + manual override

### DIFF
--- a/src-tauri/src/ai/cli.rs
+++ b/src-tauri/src/ai/cli.rs
@@ -8,15 +8,135 @@
 //! (CVE-2024-24576 patch), so passing the full `.cmd` path to `Command::new`
 //! works correctly on Windows.
 //!
-//! On Linux/macOS PATH lookup already works for any executable, but using
-//! `which` is still consistent and avoids a second PATH walk inside the OS.
+//! On macOS / Linux PATH lookup theoretically works for any executable, but
+//! GUI apps on macOS (Finder, Dock, Spotlight) launch with a minimal PATH
+//! that does NOT include Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`),
+//! npm-global, volta/nvm, bun, or `~/.local/bin` — so binaries installed via
+//! the user's shell are invisible. Linux desktop launchers (.desktop files)
+//! exhibit the same problem when DE PATH differs from the user's shell PATH.
+//! Resolution strategy on Unix: process PATH → curated fallback dirs → login
+//! shell probe (`zsh -lc 'command -v <name>'` or equivalent). See issue #70.
 
 use std::ffi::OsString;
+use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
+
+/// Resolve `name` with optional explicit override path. The override always
+/// wins when it points to an existing file — even on Unix where executable
+/// bit checks would normally apply, since the user explicitly picked it.
+pub fn resolve_with_override(name: &str, override_path: Option<&str>) -> OsString {
+    if let Some(p) = override_path {
+        let trimmed = p.trim();
+        if !trimmed.is_empty() {
+            let candidate = Path::new(trimmed);
+            if candidate.is_file() {
+                return candidate.as_os_str().to_os_string();
+            }
+        }
+    }
+    resolve(name)
+}
 
 pub fn resolve(name: &str) -> OsString {
-    which::which(name)
-        .map(|p| p.into_os_string())
-        .unwrap_or_else(|_| OsString::from(name))
+    if let Ok(p) = which::which(name) {
+        return p.into_os_string();
+    }
+    #[cfg(unix)]
+    {
+        if let Some(p) = resolve_unix_fallback(name) {
+            return p.into_os_string();
+        }
+        if let Some(p) = resolve_via_login_shell(name) {
+            return p.into_os_string();
+        }
+    }
+    OsString::from(name)
+}
+
+#[cfg(unix)]
+fn resolve_unix_fallback(name: &str) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut candidates: Vec<PathBuf> = vec![
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/opt/homebrew/sbin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/usr/local/sbin"),
+        PathBuf::from("/usr/bin"),
+        PathBuf::from("/bin"),
+    ];
+    if let Some(h) = home {
+        candidates.extend([
+            h.join(".npm-global/bin"),
+            h.join(".npm/bin"),
+            h.join(".bun/bin"),
+            h.join(".volta/bin"),
+            h.join(".nvm/versions/node"),
+            h.join(".cargo/bin"),
+            h.join(".local/bin"),
+            h.join("bin"),
+        ]);
+    }
+    for dir in candidates {
+        let direct = dir.join(name);
+        if is_executable_file(&direct) {
+            return Some(direct);
+        }
+        // nvm: ~/.nvm/versions/node/vX.Y.Z/bin/<name> — try one level deeper.
+        if dir.file_name().map(|n| n == "node").unwrap_or(false) {
+            if let Ok(rd) = std::fs::read_dir(&dir) {
+                for entry in rd.flatten() {
+                    let inner = entry.path().join("bin").join(name);
+                    if is_executable_file(&inner) {
+                        return Some(inner);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(p: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(p) {
+        Ok(m) if m.is_file() => m.permissions().mode() & 0o111 != 0,
+        _ => false,
+    }
+}
+
+/// Last-ditch: ask the user's login shell to resolve the binary. Login shells
+/// source `~/.zprofile`, `~/.bash_profile`, etc. which set PATH to whatever the
+/// user actually uses interactively. Costs one shell startup (~50–150 ms) but
+/// only runs when the curated fallbacks miss.
+#[cfg(unix)]
+fn resolve_via_login_shell(name: &str) -> Option<PathBuf> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let cmd = format!("command -v {}", shell_escape(name));
+    let out = std::process::Command::new(&shell)
+        .arg("-lc")
+        .arg(cmd)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let path = stdout.lines().next()?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    let buf = PathBuf::from(path);
+    if buf.is_file() { Some(buf) } else { None }
+}
+
+#[cfg(unix)]
+fn shell_escape(s: &str) -> String {
+    // Wrap in single quotes; escape embedded quotes via '\''. Binary names
+    // in practice never contain quotes, but be defensive.
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{}'", escaped)
 }
 
 /// Suppress the console window that Windows pops up for every spawned CLI

--- a/src-tauri/src/ai/health/claude.rs
+++ b/src-tauri/src/ai/health/claude.rs
@@ -23,8 +23,8 @@ use crate::ai::cli;
 
 const CMD: &str = "claude";
 
-pub async fn probe() -> HealthStatus {
-    let version = match run_capture(&["--version"], 5).await {
+pub async fn probe(override_path: Option<&str>) -> HealthStatus {
+    let version = match run_capture(override_path, &["--version"], 5).await {
         Ok((true, out, _)) => Some(out.trim().to_string()),
         _ => {
             return HealthStatus {
@@ -38,7 +38,7 @@ pub async fn probe() -> HealthStatus {
     // Optional dedicated auth probe (claude doctor). If unavailable, treat
     // version-success as healthy — Claude Code holds its credential in the
     // browser session; we can't probe auth without making a real request.
-    let auth = run_capture(&["doctor"], 10).await;
+    let auth = run_capture(override_path, &["doctor"], 10).await;
     match auth {
         Ok((true, out, _)) => {
             let account = parse_account(&out);
@@ -64,11 +64,12 @@ fn parse_account(out: &str) -> Option<String> {
 }
 
 async fn run_capture(
+    override_path: Option<&str>,
     args: &[&str],
     timeout_secs: u64,
 ) -> Result<(bool, String, String), String> {
     let fut = async {
-        let mut cmd = Command::new(cli::resolve(CMD));
+        let mut cmd = Command::new(cli::resolve_with_override(CMD, override_path));
         cmd.args(args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/src-tauri/src/ai/health/codex.rs
+++ b/src-tauri/src/ai/health/codex.rs
@@ -21,8 +21,8 @@ use crate::ai::cli;
 
 const CMD: &str = "codex";
 
-pub async fn probe() -> HealthStatus {
-    let version = match run_capture(&["--version"], 5).await {
+pub async fn probe(override_path: Option<&str>) -> HealthStatus {
+    let version = match run_capture(override_path, &["--version"], 5).await {
         Ok((true, out, _)) => Some(out.trim().to_string()),
         _ => {
             return HealthStatus {
@@ -33,7 +33,7 @@ pub async fn probe() -> HealthStatus {
             }
         }
     };
-    let auth = run_capture(&["login", "status"], 10).await;
+    let auth = run_capture(override_path, &["login", "status"], 10).await;
     match auth {
         Ok((true, out, _)) => {
             HealthStatus { ok: true, version, account: parse_account(&out), error: None }
@@ -67,11 +67,12 @@ fn parse_account(out: &str) -> Option<String> {
 }
 
 async fn run_capture(
+    override_path: Option<&str>,
     args: &[&str],
     timeout_secs: u64,
 ) -> Result<(bool, String, String), String> {
     let fut = async {
-        let mut cmd = Command::new(cli::resolve(CMD));
+        let mut cmd = Command::new(cli::resolve_with_override(CMD, override_path));
         cmd.args(args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());

--- a/src-tauri/src/ai/health/mod.rs
+++ b/src-tauri/src/ai/health/mod.rs
@@ -3,9 +3,9 @@ pub mod codex;
 
 use crate::ai::types::{CliKind, HealthStatus};
 
-pub async fn check(cli: CliKind) -> HealthStatus {
+pub async fn check(cli: CliKind, override_path: Option<&str>) -> HealthStatus {
     match cli {
-        CliKind::Claude => claude::probe().await,
-        CliKind::Codex => codex::probe().await,
+        CliKind::Claude => claude::probe(override_path).await,
+        CliKind::Codex => codex::probe(override_path).await,
     }
 }

--- a/src-tauri/src/ai/process/claude.rs
+++ b/src-tauri/src/ai/process/claude.rs
@@ -22,7 +22,7 @@ use crate::ai::cli;
 const CMD: &str = "claude";
 
 pub async fn spawn(req: &AiSendRequest) -> Result<Child, String> {
-    let mut cmd = Command::new(cli::resolve(CMD));
+    let mut cmd = Command::new(cli::resolve_with_override(CMD, req.cli_path.as_deref()));
     cmd.arg("-p")
         .arg("--output-format").arg("stream-json")
         .arg("--verbose")  // REQUIRED for stream-json to actually emit

--- a/src-tauri/src/ai/process/codex.rs
+++ b/src-tauri/src/ai/process/codex.rs
@@ -37,7 +37,7 @@ const CMD: &str = "codex";
 /// arguments are invalid"); (b) stdin is the documented escape hatch for
 /// codex when "instructions are read from stdin".
 pub async fn spawn(req: &AiSendRequest) -> Result<Child, String> {
-    let mut cmd = Command::new(cli::resolve(CMD));
+    let mut cmd = Command::new(cli::resolve_with_override(CMD, req.cli_path.as_deref()));
 
     // codex `exec resume` does not surface `-i <FILE>`. If the user attached
     // images to this turn, we MUST take the new-session path so the images

--- a/src-tauri/src/ai/process/mod.rs
+++ b/src-tauri/src/ai/process/mod.rs
@@ -30,6 +30,12 @@ pub struct AiSendRequest {
     /// content blocks — wired in a follow-up).
     #[serde(default)]
     pub images: Vec<String>,
+    /// Optional user-supplied path to the CLI binary, taking precedence over
+    /// PATH-based resolution. Used on macOS/Linux when the binary lives
+    /// outside the GUI process's PATH (Homebrew, npm-global, volta, etc.).
+    /// Empty / None falls back to `cli::resolve`. See issue #70.
+    #[serde(default)]
+    pub cli_path: Option<String>,
 }
 
 pub async fn spawn(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,8 +151,8 @@ async fn transfer_tab_to_window(
 use ai::types::{AccessMap, AuditEntry, CliKind, HealthStatus, SessionMapping, SnapshotIndexEntry};
 
 #[tauri::command]
-async fn ai_health_check(cli: CliKind) -> HealthStatus {
-    ai::health::check(cli).await
+async fn ai_health_check(cli: CliKind, override_path: Option<String>) -> HealthStatus {
+    ai::health::check(cli, override_path.as_deref()).await
 }
 
 #[tauri::command]

--- a/src/__tests__/services/aiCommands.test.ts
+++ b/src/__tests__/services/aiCommands.test.ts
@@ -19,8 +19,16 @@ describe('aiCommands', () => {
       ok: true, version: '1', account: 'a', error: null,
     });
     const r = await aiCommands.healthCheck('claude');
-    expect(invoke).toHaveBeenCalledWith('ai_health_check', { cli: 'claude' });
+    expect(invoke).toHaveBeenCalledWith('ai_health_check', { cli: 'claude', overridePath: null });
     expect(r.ok).toBe(true);
+  });
+
+  it('healthCheck forwards an explicit override path when provided', async () => {
+    (invoke as unknown as { mockResolvedValue: (v: unknown) => void }).mockResolvedValue({
+      ok: true, version: '1', account: null, error: null,
+    });
+    await aiCommands.healthCheck('codex', '/opt/homebrew/bin/codex');
+    expect(invoke).toHaveBeenCalledWith('ai_health_check', { cli: 'codex', overridePath: '/opt/homebrew/bin/codex' });
   });
 
   it('send forwards the request payload as `req` and requestId', async () => {

--- a/src/components/ai/AiSettingsTab.vue
+++ b/src/components/ai/AiSettingsTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
 import { open as openExternal } from '@tauri-apps/plugin-shell';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { useI18n } from '../../i18n';
 import { useSettings, type CliKind, type PanelSide } from '../../composables/useSettings';
 import { useAi } from '../../composables/useAi';
@@ -20,6 +21,8 @@ const {
   setAiSnapshotsKeep,
   setAiPanelSide,
   setAiHasSeenFirstRun,
+  setAiCliPathClaude,
+  setAiCliPathCodex,
 } = useSettings();
 const { check, cache, loading } = useAiHealth();
 const { bypassEnabled } = useAi();
@@ -73,6 +76,83 @@ const installUrl: Record<CliKind, string> = {
 
 async function openInstall(cli: CliKind) {
   await openExternal(installUrl[cli]);
+}
+
+function setCliPath(cli: CliKind, value: string) {
+  if (cli === 'claude') setAiCliPathClaude(value);
+  else setAiCliPathCodex(value);
+}
+
+function getCliPath(cli: CliKind): string {
+  return cli === 'claude' ? settings.value.ai.cliPathClaude : settings.value.ai.cliPathCodex;
+}
+
+async function browseCliPath(cli: CliKind) {
+  try {
+    const picked = await openDialog({
+      multiple: false,
+      directory: false,
+      title: cli === 'claude' ? 'Select claude binary' : 'Select codex binary',
+    });
+    if (typeof picked === 'string' && picked.trim()) {
+      setCliPath(cli, picked);
+      await check(cli, true);
+    }
+  } catch (e) {
+    console.error('[AiSettings] browseCliPath failed:', e);
+  }
+}
+
+async function applyCliPath(cli: CliKind, value: string) {
+  setCliPath(cli, value);
+  await check(cli, true);
+}
+
+type OsKind = 'mac' | 'win' | 'linux';
+
+function detectOs(): OsKind {
+  const ua = (navigator.userAgent || '').toLowerCase();
+  const plat = (navigator.platform || '').toLowerCase();
+  if (ua.includes('mac') || plat.includes('mac')) return 'mac';
+  if (ua.includes('win') || plat.includes('win')) return 'win';
+  return 'linux';
+}
+
+const currentOs = detectOs();
+
+function placeholderFor(cli: CliKind): string {
+  switch (currentOs) {
+    case 'mac':
+      return `/opt/homebrew/bin/${cli}`;
+    case 'win':
+      return `C:\\Users\\<you>\\AppData\\Roaming\\npm\\${cli}.cmd`;
+    default:
+      return `/usr/local/bin/${cli}`;
+  }
+}
+
+function searchedPaths(): string[] {
+  switch (currentOs) {
+    case 'mac':
+      return [
+        'PATH (incl. /opt/homebrew/bin, /usr/local/bin)',
+        '~/.npm-global/bin, ~/.bun/bin, ~/.volta/bin, ~/.cargo/bin',
+        '~/.nvm/versions/node/*/bin, ~/.local/bin',
+        'login shell (zsh -lc) — sources ~/.zprofile, ~/.zshrc',
+      ];
+    case 'win':
+      return [
+        'PATH with PATHEXT (.exe / .cmd / .bat)',
+        'no extra fallbacks — install via npm / scoop / winget keeps PATH set',
+      ];
+    default:
+      return [
+        'PATH (incl. /usr/local/bin, /usr/bin)',
+        '~/.npm-global/bin, ~/.bun/bin, ~/.volta/bin, ~/.cargo/bin',
+        '~/.nvm/versions/node/*/bin, ~/.local/bin',
+        'login shell ($SHELL -lc) — sources ~/.bashrc / ~/.zshrc',
+      ];
+  }
 }
 
 function isCustom(cli: 'claude' | 'codex'): boolean {
@@ -130,24 +210,51 @@ async function copyAudit() {
 
     <section class="ai-settings-section">
       <h4>{{ t.aiSettingsCliHeading }}</h4>
-      <div v-for="cli in (['claude', 'codex'] as CliKind[])" :key="cli" class="ai-cli-row">
-        <div class="ai-cli-name-col">
-          <span class="ai-cli-name">{{ cli === 'claude' ? t.aiCliStatusClaude : t.aiCliStatusCodex }}</span>
-          <span class="ai-cli-sub">{{ cache[cli]?.version ?? '' }}</span>
+      <div v-for="cli in (['claude', 'codex'] as CliKind[])" :key="cli" class="ai-cli-block">
+        <div class="ai-cli-row">
+          <div class="ai-cli-name-col">
+            <span class="ai-cli-name">{{ cli === 'claude' ? t.aiCliStatusClaude : t.aiCliStatusCodex }}</span>
+            <span class="ai-cli-sub">{{ cache[cli]?.version ?? '' }}</span>
+          </div>
+          <div class="ai-cli-status-col">
+            <span class="ai-cli-dot" :class="dotClass(cli)" />
+            <span class="ai-cli-status">{{ statusText(cli) }}</span>
+            <small v-if="cache[cli]?.error" class="ai-cli-err">{{ cache[cli]?.error }}</small>
+          </div>
+          <div class="ai-cli-actions">
+            <button class="ai-btn" @click="recheck(cli)" :disabled="loading[cli]">
+              {{ loading[cli] ? '…' : t.aiRecheck }}
+            </button>
+            <button v-if="!statusOk(cli)" class="ai-btn ai-btn--secondary" @click="openInstall(cli)">
+              {{ t.aiInstall }}
+            </button>
+          </div>
         </div>
-        <div class="ai-cli-status-col">
-          <span class="ai-cli-dot" :class="dotClass(cli)" />
-          <span class="ai-cli-status">{{ statusText(cli) }}</span>
-          <small v-if="cache[cli]?.error" class="ai-cli-err">{{ cache[cli]?.error }}</small>
-        </div>
-        <div class="ai-cli-actions">
-          <button class="ai-btn" @click="recheck(cli)" :disabled="loading[cli]">
-            {{ loading[cli] ? '…' : t.aiRecheck }}
-          </button>
-          <button v-if="!statusOk(cli)" class="ai-btn ai-btn--secondary" @click="openInstall(cli)">
-            {{ t.aiInstall }}
-          </button>
-        </div>
+        <details class="ai-cli-path">
+          <summary>{{ t.aiSettingsCliPathHeading }}</summary>
+          <div class="ai-cli-path-row">
+            <input
+              type="text"
+              :value="getCliPath(cli)"
+              :placeholder="placeholderFor(cli)"
+              @change="applyCliPath(cli, ($event.target as HTMLInputElement).value)"
+            />
+            <button class="ai-btn" @click="browseCliPath(cli)">
+              {{ t.aiSettingsCliPathBrowse }}
+            </button>
+            <button
+              class="ai-btn"
+              v-if="getCliPath(cli)"
+              @click="applyCliPath(cli, '')"
+            >
+              {{ t.aiSettingsCliPathClear }}
+            </button>
+          </div>
+          <small class="ai-helper ai-helper--inline">{{ t.aiSettingsCliPathHelper }}</small>
+          <ul class="ai-cli-path-searched">
+            <li v-for="(p, i) in searchedPaths()" :key="i">{{ p }}</li>
+          </ul>
+        </details>
       </div>
     </section>
 
@@ -385,6 +492,7 @@ async function copyAudit() {
 }
 
 /* CLI rows — kept from previous polish */
+.ai-cli-block { padding: 4px 0; }
 .ai-cli-row {
   display: grid;
   grid-template-columns: 160px 1fr auto;
@@ -392,6 +500,35 @@ async function copyAudit() {
   align-items: center;
   padding: 10px 0;
 }
+.ai-cli-path {
+  margin: 0 0 8px 0;
+  padding: 0 0 6px 0;
+}
+.ai-cli-path > summary {
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 2px 0;
+}
+.ai-cli-path > summary:hover { color: var(--text-secondary); }
+.ai-cli-path-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-top: 6px;
+}
+.ai-cli-path-row input[type="text"] { flex: 1; min-width: 200px; }
+.ai-helper--inline { padding-left: 0; margin-top: 4px; }
+.ai-cli-path-searched {
+  margin: 6px 0 0;
+  padding-left: 18px;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-family: var(--code-font-family, monospace);
+  list-style: disc;
+}
+.ai-cli-path-searched li { margin: 2px 0; }
 .ai-cli-name { font-weight: 600; font-size: 13px; color: var(--text-primary); }
 .ai-cli-sub {
   display: block;

--- a/src/composables/useAi.ts
+++ b/src/composables/useAi.ts
@@ -1,6 +1,7 @@
 import { ref, computed, watch } from 'vue';
 import { aiCommands, type AiSendRequest, type AiResponseChunk, type CliKind, type AccessMap } from '../services/aiCommands';
 import { useAiContext } from './useAiContext';
+import { useSettings } from './useSettings';
 
 export interface AttachedPin {
   id: string;
@@ -314,6 +315,11 @@ export function useAi() {
       }
     });
 
+    const { settings } = useSettings();
+    const overridePath = (opts.cli === 'claude'
+      ? settings.value.ai.cliPathClaude
+      : settings.value.ai.cliPathCodex
+    ).trim();
     const req: AiSendRequest = {
       cli: opts.cli,
       sessionId: opts.sessionId,
@@ -325,6 +331,7 @@ export function useAi() {
       bypass: bypassEnabled.value,
       workDir: opts.workDir,
       images: opts.images ?? [],
+      cliPath: overridePath || null,
     };
 
     try {

--- a/src/composables/useAiHealth.ts
+++ b/src/composables/useAiHealth.ts
@@ -1,18 +1,27 @@
 import { ref } from 'vue';
 import { aiCommands, type CliKind, type HealthStatus } from '../services/aiCommands';
+import { useSettings } from './useSettings';
 
 const cache = ref<Record<CliKind, HealthStatus | null>>({ claude: null, codex: null });
 const lastCheckedAt = ref<Record<CliKind, number | null>>({ claude: null, codex: null });
 const loading = ref<Record<CliKind, boolean>>({ claude: false, codex: false });
 
 export function useAiHealth() {
+  const { settings } = useSettings();
+
+  function overrideFor(cli: CliKind): string | null {
+    const raw = cli === 'claude' ? settings.value.ai.cliPathClaude : settings.value.ai.cliPathCodex;
+    const trimmed = (raw ?? '').trim();
+    return trimmed || null;
+  }
+
   async function check(cli: CliKind, force = false): Promise<HealthStatus> {
     if (!force && cache.value[cli]) {
       return cache.value[cli] as HealthStatus;
     }
     loading.value[cli] = true;
     try {
-      const r = await aiCommands.healthCheck(cli);
+      const r = await aiCommands.healthCheck(cli, overrideFor(cli));
       cache.value[cli] = r;
       lastCheckedAt.value[cli] = Date.now();
       return r;

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -18,6 +18,10 @@ export interface AiSettings {
   snapshotsKeep: number;
   hasSeenFirstRun: boolean;
   panelSide: PanelSide;
+  /** Optional manual override for the `claude` binary path. Empty = autodetect via PATH. */
+  cliPathClaude: string;
+  /** Optional manual override for the `codex` binary path. Empty = autodetect via PATH. */
+  cliPathCodex: string;
 }
 
 export interface FontPreset {
@@ -159,6 +163,8 @@ function getDefaultSettings(): AppSettings {
       snapshotsKeep: 3,
       hasSeenFirstRun: false,
       panelSide: 'right',
+      cliPathClaude: '',
+      cliPathCodex: '',
     },
   };
 }
@@ -264,6 +270,8 @@ export function useSettings() {
   };
   const setAiHasSeenFirstRun = (v: boolean) => { settings.value.ai.hasSeenFirstRun = v; };
   const setAiPanelSide = (v: PanelSide) => { settings.value.ai.panelSide = v; };
+  const setAiCliPathClaude = (v: string) => { settings.value.ai.cliPathClaude = v.trim(); };
+  const setAiCliPathCodex = (v: string) => { settings.value.ai.cliPathCodex = v.trim(); };
 
   return {
     settings,
@@ -294,6 +302,8 @@ export function useSettings() {
     setAiSnapshotsKeep,
     setAiHasSeenFirstRun,
     setAiPanelSide,
+    setAiCliPathClaude,
+    setAiCliPathCodex,
   };
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -399,6 +399,11 @@ export interface Translations {
   aiSettingsEffortHeading: string;
   aiSettingsCopyAudit: string;
   aiSettingsModelIdPlaceholder: string;
+  aiSettingsCliPathHeading: string;
+  aiSettingsCliPathHelper: string;
+  aiSettingsCliPathBrowse: string;
+  aiSettingsCliPathPlaceholder: string;
+  aiSettingsCliPathClear: string;
   collapseSidebar: string;
   expandSidebar: string;
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -393,6 +393,11 @@ const en: Translations = {
   aiSettingsEffortHeading: 'Effort',
   aiSettingsCopyAudit: 'Copy',
   aiSettingsModelIdPlaceholder: 'model id',
+  aiSettingsCliPathHeading: 'Custom binary path',
+  aiSettingsCliPathHelper: 'Use only if auto-detection fails (macOS GUI apps often miss Homebrew/npm-global PATH; or non-standard installs via asdf/mise/fnm/snap). Leave empty to autodetect. Searched locations:',
+  aiSettingsCliPathBrowse: 'Browse…',
+  aiSettingsCliPathPlaceholder: 'e.g. /opt/homebrew/bin/claude',
+  aiSettingsCliPathClear: 'Clear',
   collapseSidebar: 'Collapse sidebar',
   expandSidebar: 'Expand sidebar',
 };

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -393,6 +393,11 @@ const pl: Translations = {
   aiSettingsEffortHeading: 'Tryb pracy',
   aiSettingsCopyAudit: 'Kopiuj',
   aiSettingsModelIdPlaceholder: 'id modelu',
+  aiSettingsCliPathHeading: 'Własna ścieżka do binarki',
+  aiSettingsCliPathHelper: 'Użyj tylko gdy automatyczne wykrywanie zawodzi (np. aplikacje GUI na macOS nie widzą PATH z Homebrew/npm-global; nietypowe instalki przez asdf/mise/fnm/snap). Puste = wykrywanie automatyczne. Sprawdzane lokalizacje:',
+  aiSettingsCliPathBrowse: 'Wybierz…',
+  aiSettingsCliPathPlaceholder: 'np. /opt/homebrew/bin/claude',
+  aiSettingsCliPathClear: 'Wyczyść',
   collapseSidebar: 'Zwiń pasek boczny',
   expandSidebar: 'Rozwiń pasek boczny',
 };

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -393,6 +393,11 @@ const zhCN: Translations = {
   aiSettingsEffortHeading: '推理强度',
   aiSettingsCopyAudit: '复制',
   aiSettingsModelIdPlaceholder: '模型 ID',
+  aiSettingsCliPathHeading: '自定义可执行文件路径',
+  aiSettingsCliPathHelper: '仅在自动检测失败时使用（例如 macOS 图形应用无法读取 Homebrew/npm-global 的 PATH；或通过 asdf/mise/fnm/snap 等非标准安装）。留空则自动检测。检测的路径：',
+  aiSettingsCliPathBrowse: '浏览…',
+  aiSettingsCliPathPlaceholder: '例如 /opt/homebrew/bin/claude',
+  aiSettingsCliPathClear: '清除',
   collapseSidebar: '收起侧边栏',
   expandSidebar: '展开侧边栏',
 };

--- a/src/services/aiCommands.ts
+++ b/src/services/aiCommands.ts
@@ -62,6 +62,8 @@ export interface AiSendRequest {
   workDir: string;
   /** Absolute paths to attached image files. */
   images?: string[];
+  /** Optional explicit path to the CLI binary (overrides PATH-based detection). */
+  cliPath?: string | null;
 }
 
 export type AiResponseChunk =
@@ -72,7 +74,8 @@ export type AiResponseChunk =
   | { kind: 'error'; message: string; exitCode: number | null };
 
 export const aiCommands = {
-  healthCheck: (cli: CliKind) => invoke<HealthStatus>('ai_health_check', { cli }),
+  healthCheck: (cli: CliKind, overridePath: string | null = null) =>
+    invoke<HealthStatus>('ai_health_check', { cli, overridePath }),
 
   send: (req: AiSendRequest, requestId: string) => invoke<string>('ai_send', { req, requestId }),
   cancel: (requestId: string) => invoke<void>('ai_cancel', { requestId }),


### PR DESCRIPTION
Closes #70.

## Problem

On macOS, GUI apps launched from Finder / Dock / Spotlight inherit a minimal `PATH` that does not include Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`), npm-global, volta, nvm or any other shell-managed prefix. The CLI resolver relied on `which::which`, which only walks the process `PATH`, so installed `claude` / `codex` binaries showed up as `Binary not found` even when they worked perfectly from the terminal. Linux desktop launchers (`.desktop` files) suffer from the same disconnect between desktop and shell `PATH`.

## Fix

**Unix resolution chain** (`src-tauri/src/ai/cli.rs`)
1. `which::which(name)` — process PATH (covers happy path).
2. Curated fallback dirs:
   - `/opt/homebrew/{bin,sbin}`, `/usr/local/{bin,sbin}`, `/usr/bin`, `/bin`
   - `~/.npm-global/bin`, `~/.npm/bin`, `~/.bun/bin`, `~/.volta/bin`, `~/.cargo/bin`, `~/.local/bin`, `~/bin`
   - `~/.nvm/versions/node/*/bin` (one extra glob level)
3. Login-shell probe: `$SHELL -lc 'command -v <name>'`. Sources `~/.zprofile` / `~/.bash_profile` / etc., so any non-standard install (asdf, mise, fnm, snap...) that the user has wired into their interactive shell is also picked up.

Windows keeps the existing `which::which` + PATHEXT behaviour — npm / scoop / winget installs already configure the user `PATH` correctly there, and there is no shell-PATH-vs-GUI-PATH gap to bridge.

**Manual override**
Added a per-CLI custom binary path field in *Settings → AI → CLI* (collapsed under each CLI status row). Plain text input + native file picker + clear button. The path is persisted in `AiSettings`, threaded through `ai_health_check` and every `ai_send` spawn (`AiSendRequest.cli_path`), and takes precedence over auto-detection. Empty string falls back to the resolver chain above.

The input renders an OS-aware placeholder and a list of the locations actually searched on the current platform, so users can see what the app already tried before reaching for the override:
- macOS: `/opt/homebrew/bin/<cli>` placeholder
- Linux: `/usr/local/bin/<cli>` placeholder
- Windows: `C:\Users\<you>\AppData\Roaming\npm\<cli>.cmd` placeholder

## Files

- `src-tauri/src/ai/cli.rs` — `resolve_with_override` + Unix fallback dirs + login-shell probe
- `src-tauri/src/ai/health/{mod,claude,codex}.rs` — `probe(override_path)`
- `src-tauri/src/ai/process/{mod,claude,codex}.rs` — `AiSendRequest.cli_path`
- `src-tauri/src/lib.rs` — `ai_health_check(cli, overridePath)`
- `src/composables/useSettings.ts` — `cliPathClaude/Codex` fields
- `src/services/aiCommands.ts`, `src/composables/useAiHealth.ts`, `src/composables/useAi.ts` — wire through
- `src/components/ai/AiSettingsTab.vue` — UI (input + Browse + Clear, OS-aware placeholder, searched-paths list)
- `src/i18n/locales/{en,pl,zh-CN}.ts` — five new strings

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --lib` — 46/46 pass
- [x] `vue-tsc --noEmit` clean
- [x] `vitest run` — 622/622 pass (existing `aiCommands.test.ts` updated for the new `overridePath` arg, new test for explicit path forwarding)
- [ ] Manual: macOS — Homebrew / npm-global install detected without override
- [ ] Manual: macOS — paste a custom `/opt/homebrew/bin/claude` path, recheck shows green
- [ ] Manual: Linux — install detected without override
- [x] Manual: Windows — regression check (still works as before)