### PR TITLE
fix: PDF diagram/table clipping + Settings Updates tab (v0.2.9)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,82 +1,8 @@
-# Release v0.2.6 — Workspaces, Minimal Theme, AI in Diagrams
+# Release v0.2.9 — PDF/print hotfix: diagrams and tables
 
-Workspace folders, a brand-new Minimal theme, AI editing for Mermaid diagrams, a near-WYSIWYG PDF export — the editor finally feels like a place you can stay in for hours, not just a quick-note tool.
-
-<p>
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/docs/release-notes/v0.2.6/ui-light-mode.png" alt="MerMark v0.2.4 — Minimal theme, workspace sidebar, document open" width="48%" />
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/docs/release-notes/v0.2.6/ui-with-ai-panel.png" alt="MerMark v0.2.4 — same layout with the AI Assistant docked on the right" width="48%" />
-</p>
-
-## Workspaces
-
-- **Multi-root workspace sidebar** (#69) — open one folder, two folders, ten. Each gets a collapsible section with file tree, drag-to-reorder header, and per-workspace controls (search, new file, open folder, menu). The active workspace shows a colored dot.
-- **Folder tree like Zettlr / Obsidian** — expand / collapse subdirectories, click a file to open in a new tab, right-click for OS-level reveal, rename, delete, new file / folder. Expanded folders are remembered between sessions.
-- **AI sees the workspace** — when a file lives inside an open workspace, the AI preamble includes the workspace root as a *read-only* scope. Ask "summarize the meeting notes from the last two weeks" and the model can actually traverse the folder; writes still stay scoped to the active document.
-- **Quick switcher** — `Ctrl+Shift+E` opens a 3-section command palette: workspaces, files (filename match), content (full-text grep across the active workspace, debounced 150 ms, capped at 5 000 files / 4 s / 200 hits so it never stalls a big tree).
-- **Migration from v0.2.x** — existing `lastRoot` workspace settings are auto-migrated to the new `openWorkspaces[]` shape on first launch.
-
-## Minimal theme
-
-- **Mermaid-logo palette** — teal `#14b8a6` and coral `#f43f5e` over slate `#1a2028`. Light and dark variants both ship; the variant axis is orthogonal to light/dark, so any combination works (Default + Light, Default + Dark, Minimal + Light, Minimal + Dark).
-- **Editor chrome only** — accents live in tabs, sidebar headers, the active workspace dot, the AI status indicator. The document content stays neutral so prose doesn't fight for attention with the chrome.
-- **Configurable padding** — Settings → General now exposes top, side, and bottom padding sliders. Values apply to both Default and Minimal themes (the previous build only wired them up for Minimal).
-- **Better code blocks in Minimal** — dark slate background with full syntax highlighting, instead of the previous flat grey selection look.
-- **Full-width horizontal rules** — `---` now spans the full content column.
-
-## AI in Mermaid diagrams
-
-- **Edit via the main AI panel** — clicking the AI button on a diagram (or in fullscreen edit) registers a target with the panel, auto-pins the diagram source as scoped context, and switches the preamble into mermaid-edit mode. You get the full panel: model picker, multi-turn conversation, threads, snapshots — same surface you use for prose.
-- **Live preview, explicit Apply** — every assistant reply is parsed for a `mermaid` fenced block. The diagram renders the proposal in place, with a chip in the panel showing **Apply ✓ / Discard × / Stop**. Apply commits to the node attrs; Discard keeps the conversation going; Stop ends the session.
-- **Coexists with fullscreen edit** — you don't have to leave the fullscreen mermaid editor to use the AI. The panel sits on top (`z-index: 100000`) so both stay visible; minimising the chat restores the diagram to full width.
-- **Robot icon, no more star** — the diagram AI button uses the same robot glyph as the main toolbar, so it's recognizable across the app.
-
-## PDF export — closer to WYSIWYG
-
-- **Match the editor** — the PDF now uses the same serif font (Charter / Iowan Old Style / Palatino) at the same scale (11.5 pt / 1.7 line-height) as the Minimal editor. What you see really is what you get.
-- **Editor padding → PDF margins** — your top / side / bottom padding settings are applied as `body` padding inside `@media print`, so a tight editor prints with tight margins and a roomy editor prints generously. The fixed `@page` margin (10 mm safety) layers on top of that.
-- **Code blocks keep their colours** — One-Dark palette (keyword purple, string green, number / attribute orange, comment grey, …) renders inside the PDF with `-webkit-text-fill-color` set explicitly so Chromium's PDF backend doesn't strip the colour. Background stays dark slate.
-- **Inline code matches the editor** — coral text (`#e11d48`) on light grey, mirroring the Minimal theme's `--danger`-tinted inline code instead of the previous teal that diverged from both on-screen variants.
-- **Tables size to content** — switched from `table-layout: fixed` (which spread one-word columns and long-URL columns to equal widths) to `auto`, so a `Method | Route | Handler` table reads the way it does in the editor.
-- **Hidden chrome, real layout** — the workspace sidebar collapses to zero width (not just `display: none`, which left a flex reservation), all dialogs / overlays / drag artefacts are gone, the document fills the printable width 1:1.
-- **No more dark-mode bleed** — earlier builds had `html.dark[data-variant="minimal"]` selectors out-ranking the print overrides; the print block now hard-pins the entire container chain to white with hex `#ffffff` instead of relying on cascading `--bg-primary`.
-
-## UI polish
-
-- **Resizable Mermaid editor split** — the divider between code and preview in fullscreen mermaid edit is draggable; the ratio is persisted into the markdown via node attrs (`splitRatio`) and survives roundtrip.
-- **Resizable diagram in document** — drag the right edge of an inline mermaid block to set a custom width; persisted as `userWidth`.
-- **Word-style zoom slider** — the editor zoom (Ctrl + Scroll, Ctrl+/-) now has a visible slider in the status bar with `±` buttons and percentage readout. Cleaner than the dropdown that lived there before.
-- **Tab pin + context menu** — right-click a tab for **Pin / Unpin / Close / Close others / Close all but pinned / Close saved / Close all**. Pinned tabs reorder to the front and survive bulk-close.
-- **Quick switcher with content search** — files and live full-text grep across the active workspace, behind `Ctrl+Shift+E`.
-- **Split file-ops button** — the toolbar `+` is now two buttons: "New file" and "Open folder", so the workspace flow is one click instead of two.
-- **Styled prompts and confirms** — the native `window.prompt` / `window.confirm` modals are replaced with themed dialogs everywhere (rename file, delete file, conflict resolution, …).
+Hotfix for two regressions in the v0.2.8 PDF/print pipeline.
 
 ## Bug fixes
 
-- **`os error 123` on Windows when the AI is asked to edit a fresh / unsaved file** — both `claude` and `codex` were getting an empty `work_dir` which Windows rejects on `Command::current_dir`. The Rust spawn helpers now fall back to `$HOME` / `$USERPROFILE` / `.` when the work dir is empty.
-- **`codex --cd ""` rejection** — same root cause on the codex side; `--cd` is now only set to a real path, and `--add-dir` is skipped when no work dir is known.
-- **Claude / Codex CLI on macOS / Linux** (#70 — also in 0.2.3) — GUI launches inherit a minimal `PATH` so installs from Homebrew / npm-global / volta / nvm / bun / asdf were not detected. The resolver now walks a curated list of standard install dirs and falls back to a login-shell probe (`$SHELL -lc 'command -v <name>'`); Settings → AI → CLI exposes a custom-path override with the actual list of locations the app searched, so you can see what was tried.
-- **AI mermaid modal not appearing on first click** — nested `<Teleport>` inside the editor fullscreen sometimes failed to mount; the modal renders in place now (and as of this release is replaced by the main AI panel anyway).
-- **PDF dark-mode bleed** — multiple iterations to defeat scoped Vue styles + `html.dark[data-variant]` rules; the entire container chain is now hex-pinned to `#ffffff` in print.
-- **PDF top margin too large in Minimal** — Minimal's `padding-top: 32px` stacked on top of the `@page :first` margin and gave a 2 cm gap; print now zeroes editor padding and uses `body` padding routed from your editor settings.
-- **Autolink URL appendix** — TipTap autolinks `CLAUDE.md` into `<a href="http://CLAUDE.md">`, and the previous `a::after { content: " (" attr(href) ")" }` rule then printed `CLAUDE.md (http://CLAUDE.md)` next to every plain-text mention. The URL appendix is gone; PDFs embed real hyperlinks anyway.
-- **Mermaid `<select>` % dropdown jankiness** — the native dropdown stole the popup layer inside the floating toolbar and the active option visually shifted on every render; replaced by four buttons (25 / 50 / 75 / 100).
-- **Default mermaid scale 25 → 100** — new diagrams render at full size by default; the previous 25 % default left them tiny in the document.
-- **Workspace sidebar visible in PDF** — `display: none` left a flex width reservation; the sidebar now collapses with `width: 0; visibility: hidden`.
-- **AI panel tab visible in fullscreen mermaid edit** — when minimised during a mermaid AI session, the tab needs to sit above the diagram fullscreen overlay. `z-index: 100000` is now applied conditionally so it only outranks the overlay during an active mermaid edit.
-- **Claude AI on Windows — `batch file arguments are invalid`** (from 0.2.5) — Claude CLI resolves to `claude.cmd` (npm shim); Rust 1.77+ rejects `.cmd` invocations with newline-bearing args (CVE-2024-24576 mitigation). The system preamble is multi-line. Spawn now uses the documented `--input-format stream-json` path universally and folds the preamble into the user message text — same pattern as the Codex spawn.
-- **Codex error events surface in the chat** (from 0.2.5) — Codex's top-level `error` / `turn.failed` envelopes were being dropped by the stdout normalizer; users got a generic *"AI process exited without finalising the turn"* instead of the real reason (e.g. *"The 'gpt-5' model is not supported when using Codex with a ChatGPT account."*). The normalizer now matches both shapes and unwraps the upstream API message.
-- **Last-stderr tail attached to "exited without finalising" errors** (from 0.2.5) — when an AI child genuinely dies without emitting a final JSON event the synthesised error chunk now includes the last 20 lines of the child's stderr so you don't need a debug build to diagnose it.
-- **Settings → AI shows resolved binary path** (from 0.2.5) — under the version line for each CLI you can see the actual path the resolver picked (`C:\Users\…\AppData\Roaming\npm\claude.cmd`, `/opt/homebrew/bin/codex`, your custom override, …). Makes it obvious which install is in use.
-- **Right-click open** (#73, from 0.2.4) — context-menu *Open with MerMark* on Windows now actually opens the file instead of failing silently.
-- **Drop file from workspace tree onto split pane** — drag a file out of the sidebar onto the left or right pane in split mode and it opens there. Works on empty panes too. Capture-phase listeners outrank TipTap/ProseMirror's own dragover handler so the cursor doesn't stick in not-allowed.
-- **Click on workspace file with zero tabs open** — after Close All, clicking a workspace file used to do nothing because `loadFileIntoTab` short-circuited on `findActiveTabIndex() === -1`. Falls through to `createNewTab` now.
-- **Window stays open after Close All when a workspace is open** — closing the last tab no longer terminates the window when at least one workspace is loaded; the sidebar stays useful for browsing, dragging, and quick-switching.
-- **Typing lag on big docs** — `useToolbarActions` is called by ~20 components (Toolbar / LeftBar / StatusBar / each ToolbarItemRenderer); each used to register its own `editor.on('update')` listener that ran `getHTML` + `htmlToMarkdown` + token recount. With many tables / code blocks this stalled typing for hundreds of milliseconds per character. Listener + token counter hoisted to module scope (one per editor); typing is responsive again.
+- **Mermaid diagrams clipped in PDF** — diagrams were cut off at the right edge in exported PDFs.
 
-## Under the hood
-
-- **AI CLI path cache** — once a `claude` / `codex` binary is resolved, the path is stored in settings (`cliResolvedPathClaude` / `cliResolvedPathCodex`) and reused on subsequent probes. Cold-start health checks are now near-instant on machines where the resolver had to do a login-shell probe.
-- **Settings migration** — `useSettings` deep-merges new fields on load (`editorPaddingTop / Bottom / X`, `openWorkspaces[]`, `activeWorkspaceId`, `cliResolvedPath*`), so existing installs upgrade without losing anything.
-- **Markdown roundtrip for mermaid attrs** — node attributes (`userWidth`, `splitRatio`, `printScale`) survive markdown serialization via a `<!--mermaid-attrs:k=v,…-->` HTML comment immediately before the fenced block, parsed back into TipTap node attrs on load.
-- **`useAiMermaidTarget` singleton** — clean bridge between the diagram node and the AI panel. The node only registers a target with `apply` and `cancel` callbacks; the singleton tracks the candidate and exposes `applyCandidate` / `discardCandidate` / `clear`. Adding new "AI edits this kind of node" surfaces will use the same pattern.
-- **`useToolbarActions` listener deduped** — Toolbar / LeftBar / StatusBar / every ToolbarItemRenderer call site used to register its own `editor.on('update')` handler, so each keystroke ran ~20 copies of `getHTML` + `htmlToMarkdown` + token recount. The listener and the token counter are now hoisted to module scope (one per editor); typing on docs with many tables / code blocks no longer stalls.

--- a/docs/release-notes/v0.2.8/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.2.8/RELEASE_NOTES.md
@@ -1,0 +1,82 @@
+# Release v0.2.6 — Workspaces, Minimal Theme, AI in Diagrams
+
+Workspace folders, a brand-new Minimal theme, AI editing for Mermaid diagrams, a near-WYSIWYG PDF export — the editor finally feels like a place you can stay in for hours, not just a quick-note tool.
+
+<p>
+  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/docs/release-notes/v0.2.6/ui-light-mode.png" alt="MerMark v0.2.4 — Minimal theme, workspace sidebar, document open" width="48%" />
+  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/docs/release-notes/v0.2.6/ui-with-ai-panel.png" alt="MerMark v0.2.4 — same layout with the AI Assistant docked on the right" width="48%" />
+</p>
+
+## Workspaces
+
+- **Multi-root workspace sidebar** (#69) — open one folder, two folders, ten. Each gets a collapsible section with file tree, drag-to-reorder header, and per-workspace controls (search, new file, open folder, menu). The active workspace shows a colored dot.
+- **Folder tree like Zettlr / Obsidian** — expand / collapse subdirectories, click a file to open in a new tab, right-click for OS-level reveal, rename, delete, new file / folder. Expanded folders are remembered between sessions.
+- **AI sees the workspace** — when a file lives inside an open workspace, the AI preamble includes the workspace root as a *read-only* scope. Ask "summarize the meeting notes from the last two weeks" and the model can actually traverse the folder; writes still stay scoped to the active document.
+- **Quick switcher** — `Ctrl+Shift+E` opens a 3-section command palette: workspaces, files (filename match), content (full-text grep across the active workspace, debounced 150 ms, capped at 5 000 files / 4 s / 200 hits so it never stalls a big tree).
+- **Migration from v0.2.x** — existing `lastRoot` workspace settings are auto-migrated to the new `openWorkspaces[]` shape on first launch.
+
+## Minimal theme
+
+- **Mermaid-logo palette** — teal `#14b8a6` and coral `#f43f5e` over slate `#1a2028`. Light and dark variants both ship; the variant axis is orthogonal to light/dark, so any combination works (Default + Light, Default + Dark, Minimal + Light, Minimal + Dark).
+- **Editor chrome only** — accents live in tabs, sidebar headers, the active workspace dot, the AI status indicator. The document content stays neutral so prose doesn't fight for attention with the chrome.
+- **Configurable padding** — Settings → General now exposes top, side, and bottom padding sliders. Values apply to both Default and Minimal themes (the previous build only wired them up for Minimal).
+- **Better code blocks in Minimal** — dark slate background with full syntax highlighting, instead of the previous flat grey selection look.
+- **Full-width horizontal rules** — `---` now spans the full content column.
+
+## AI in Mermaid diagrams
+
+- **Edit via the main AI panel** — clicking the AI button on a diagram (or in fullscreen edit) registers a target with the panel, auto-pins the diagram source as scoped context, and switches the preamble into mermaid-edit mode. You get the full panel: model picker, multi-turn conversation, threads, snapshots — same surface you use for prose.
+- **Live preview, explicit Apply** — every assistant reply is parsed for a `mermaid` fenced block. The diagram renders the proposal in place, with a chip in the panel showing **Apply ✓ / Discard × / Stop**. Apply commits to the node attrs; Discard keeps the conversation going; Stop ends the session.
+- **Coexists with fullscreen edit** — you don't have to leave the fullscreen mermaid editor to use the AI. The panel sits on top (`z-index: 100000`) so both stay visible; minimising the chat restores the diagram to full width.
+- **Robot icon, no more star** — the diagram AI button uses the same robot glyph as the main toolbar, so it's recognizable across the app.
+
+## PDF export — closer to WYSIWYG
+
+- **Match the editor** — the PDF now uses the same serif font (Charter / Iowan Old Style / Palatino) at the same scale (11.5 pt / 1.7 line-height) as the Minimal editor. What you see really is what you get.
+- **Editor padding → PDF margins** — your top / side / bottom padding settings are applied as `body` padding inside `@media print`, so a tight editor prints with tight margins and a roomy editor prints generously. The fixed `@page` margin (10 mm safety) layers on top of that.
+- **Code blocks keep their colours** — One-Dark palette (keyword purple, string green, number / attribute orange, comment grey, …) renders inside the PDF with `-webkit-text-fill-color` set explicitly so Chromium's PDF backend doesn't strip the colour. Background stays dark slate.
+- **Inline code matches the editor** — coral text (`#e11d48`) on light grey, mirroring the Minimal theme's `--danger`-tinted inline code instead of the previous teal that diverged from both on-screen variants.
+- **Tables size to content** — switched from `table-layout: fixed` (which spread one-word columns and long-URL columns to equal widths) to `auto`, so a `Method | Route | Handler` table reads the way it does in the editor.
+- **Hidden chrome, real layout** — the workspace sidebar collapses to zero width (not just `display: none`, which left a flex reservation), all dialogs / overlays / drag artefacts are gone, the document fills the printable width 1:1.
+- **No more dark-mode bleed** — earlier builds had `html.dark[data-variant="minimal"]` selectors out-ranking the print overrides; the print block now hard-pins the entire container chain to white with hex `#ffffff` instead of relying on cascading `--bg-primary`.
+
+## UI polish
+
+- **Resizable Mermaid editor split** — the divider between code and preview in fullscreen mermaid edit is draggable; the ratio is persisted into the markdown via node attrs (`splitRatio`) and survives roundtrip.
+- **Resizable diagram in document** — drag the right edge of an inline mermaid block to set a custom width; persisted as `userWidth`.
+- **Word-style zoom slider** — the editor zoom (Ctrl + Scroll, Ctrl+/-) now has a visible slider in the status bar with `±` buttons and percentage readout. Cleaner than the dropdown that lived there before.
+- **Tab pin + context menu** — right-click a tab for **Pin / Unpin / Close / Close others / Close all but pinned / Close saved / Close all**. Pinned tabs reorder to the front and survive bulk-close.
+- **Quick switcher with content search** — files and live full-text grep across the active workspace, behind `Ctrl+Shift+E`.
+- **Split file-ops button** — the toolbar `+` is now two buttons: "New file" and "Open folder", so the workspace flow is one click instead of two.
+- **Styled prompts and confirms** — the native `window.prompt` / `window.confirm` modals are replaced with themed dialogs everywhere (rename file, delete file, conflict resolution, …).
+
+## Bug fixes
+
+- **`os error 123` on Windows when the AI is asked to edit a fresh / unsaved file** — both `claude` and `codex` were getting an empty `work_dir` which Windows rejects on `Command::current_dir`. The Rust spawn helpers now fall back to `$HOME` / `$USERPROFILE` / `.` when the work dir is empty.
+- **`codex --cd ""` rejection** — same root cause on the codex side; `--cd` is now only set to a real path, and `--add-dir` is skipped when no work dir is known.
+- **Claude / Codex CLI on macOS / Linux** (#70 — also in 0.2.3) — GUI launches inherit a minimal `PATH` so installs from Homebrew / npm-global / volta / nvm / bun / asdf were not detected. The resolver now walks a curated list of standard install dirs and falls back to a login-shell probe (`$SHELL -lc 'command -v <name>'`); Settings → AI → CLI exposes a custom-path override with the actual list of locations the app searched, so you can see what was tried.
+- **AI mermaid modal not appearing on first click** — nested `<Teleport>` inside the editor fullscreen sometimes failed to mount; the modal renders in place now (and as of this release is replaced by the main AI panel anyway).
+- **PDF dark-mode bleed** — multiple iterations to defeat scoped Vue styles + `html.dark[data-variant]` rules; the entire container chain is now hex-pinned to `#ffffff` in print.
+- **PDF top margin too large in Minimal** — Minimal's `padding-top: 32px` stacked on top of the `@page :first` margin and gave a 2 cm gap; print now zeroes editor padding and uses `body` padding routed from your editor settings.
+- **Autolink URL appendix** — TipTap autolinks `CLAUDE.md` into `<a href="http://CLAUDE.md">`, and the previous `a::after { content: " (" attr(href) ")" }` rule then printed `CLAUDE.md (http://CLAUDE.md)` next to every plain-text mention. The URL appendix is gone; PDFs embed real hyperlinks anyway.
+- **Mermaid `<select>` % dropdown jankiness** — the native dropdown stole the popup layer inside the floating toolbar and the active option visually shifted on every render; replaced by four buttons (25 / 50 / 75 / 100).
+- **Default mermaid scale 25 → 100** — new diagrams render at full size by default; the previous 25 % default left them tiny in the document.
+- **Workspace sidebar visible in PDF** — `display: none` left a flex width reservation; the sidebar now collapses with `width: 0; visibility: hidden`.
+- **AI panel tab visible in fullscreen mermaid edit** — when minimised during a mermaid AI session, the tab needs to sit above the diagram fullscreen overlay. `z-index: 100000` is now applied conditionally so it only outranks the overlay during an active mermaid edit.
+- **Claude AI on Windows — `batch file arguments are invalid`** (from 0.2.5) — Claude CLI resolves to `claude.cmd` (npm shim); Rust 1.77+ rejects `.cmd` invocations with newline-bearing args (CVE-2024-24576 mitigation). The system preamble is multi-line. Spawn now uses the documented `--input-format stream-json` path universally and folds the preamble into the user message text — same pattern as the Codex spawn.
+- **Codex error events surface in the chat** (from 0.2.5) — Codex's top-level `error` / `turn.failed` envelopes were being dropped by the stdout normalizer; users got a generic *"AI process exited without finalising the turn"* instead of the real reason (e.g. *"The 'gpt-5' model is not supported when using Codex with a ChatGPT account."*). The normalizer now matches both shapes and unwraps the upstream API message.
+- **Last-stderr tail attached to "exited without finalising" errors** (from 0.2.5) — when an AI child genuinely dies without emitting a final JSON event the synthesised error chunk now includes the last 20 lines of the child's stderr so you don't need a debug build to diagnose it.
+- **Settings → AI shows resolved binary path** (from 0.2.5) — under the version line for each CLI you can see the actual path the resolver picked (`C:\Users\…\AppData\Roaming\npm\claude.cmd`, `/opt/homebrew/bin/codex`, your custom override, …). Makes it obvious which install is in use.
+- **Right-click open** (#73, from 0.2.4) — context-menu *Open with MerMark* on Windows now actually opens the file instead of failing silently.
+- **Drop file from workspace tree onto split pane** — drag a file out of the sidebar onto the left or right pane in split mode and it opens there. Works on empty panes too. Capture-phase listeners outrank TipTap/ProseMirror's own dragover handler so the cursor doesn't stick in not-allowed.
+- **Click on workspace file with zero tabs open** — after Close All, clicking a workspace file used to do nothing because `loadFileIntoTab` short-circuited on `findActiveTabIndex() === -1`. Falls through to `createNewTab` now.
+- **Window stays open after Close All when a workspace is open** — closing the last tab no longer terminates the window when at least one workspace is loaded; the sidebar stays useful for browsing, dragging, and quick-switching.
+- **Typing lag on big docs** — `useToolbarActions` is called by ~20 components (Toolbar / LeftBar / StatusBar / each ToolbarItemRenderer); each used to register its own `editor.on('update')` listener that ran `getHTML` + `htmlToMarkdown` + token recount. With many tables / code blocks this stalled typing for hundreds of milliseconds per character. Listener + token counter hoisted to module scope (one per editor); typing is responsive again.
+
+## Under the hood
+
+- **AI CLI path cache** — once a `claude` / `codex` binary is resolved, the path is stored in settings (`cliResolvedPathClaude` / `cliResolvedPathCodex`) and reused on subsequent probes. Cold-start health checks are now near-instant on machines where the resolver had to do a login-shell probe.
+- **Settings migration** — `useSettings` deep-merges new fields on load (`editorPaddingTop / Bottom / X`, `openWorkspaces[]`, `activeWorkspaceId`, `cliResolvedPath*`), so existing installs upgrade without losing anything.
+- **Markdown roundtrip for mermaid attrs** — node attributes (`userWidth`, `splitRatio`, `printScale`) survive markdown serialization via a `<!--mermaid-attrs:k=v,…-->` HTML comment immediately before the fenced block, parsed back into TipTap node attrs on load.
+- **`useAiMermaidTarget` singleton** — clean bridge between the diagram node and the AI panel. The node only registers a target with `apply` and `cancel` callbacks; the singleton tracks the candidate and exposes `applyCandidate` / `discardCandidate` / `clear`. Adding new "AI edits this kind of node" surfaces will use the same pattern.
+- **`useToolbarActions` listener deduped** — Toolbar / LeftBar / StatusBar / every ToolbarItemRenderer call site used to register its own `editor.on('update')` handler, so each keystroke ran ~20 copies of `getHTML` + `htmlToMarkdown` + token recount. The listener and the token counter are now hoisted to module scope (one per editor); typing on docs with many tables / code blocks no longer stalls.

--- a/src/components/MermaidNode.vue
+++ b/src/components/MermaidNode.vue
@@ -1528,15 +1528,18 @@ html.dark .mermaid-content :deep(svg .messageLine1) {
   }
 
   .mermaid-content {
-    display: flex !important;
+    display: block !important;
     transform: none !important;
-    justify-content: center !important;
+    text-align: center !important;
     background: white !important;
     padding: 10px 0 !important;
+    width: 100% !important;
   }
 
-  /* SVG root — force light background */
+  /* SVG root — force light background, fit to page width */
   .mermaid-content :deep(svg) {
+    width: 100% !important;
+    max-width: 100% !important;
     height: auto !important;
     background: white !important;
     -webkit-print-color-adjust: exact !important;

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -8,6 +8,7 @@ import { useSystemFonts } from '../composables/useSystemFonts';
 import { useLayoutConfig, type LayoutZone } from '../composables/useLayoutConfig';
 import { getItemDef } from '../data/toolbarItems';
 import AiSettingsTab from './ai/AiSettingsTab.vue';
+import { useAutoUpdate } from '../composables/useAutoUpdate';
 
 const { t, locale, setLocale, availableLocales, localeLabels } = useI18n();
 const {
@@ -45,8 +46,19 @@ const editorSystemFonts = computed(() =>
 );
 const codeSystemFonts = computed(() => monoFonts.value);
 
-type SettingsTab = 'appearance' | 'editor' | 'code' | 'general' | 'layout' | 'ai';
+type SettingsTab = 'appearance' | 'editor' | 'code' | 'general' | 'layout' | 'ai' | 'updates';
 const activeTab = ref<SettingsTab>('editor');
+
+const {
+  updateInfo,
+  updateProgress,
+  isUpdating,
+  updateError,
+  isCheckingForUpdates,
+  noUpdateFound,
+  checkForUpdatesManual,
+  downloadAndInstallUpdate,
+} = useAutoUpdate();
 
 // ============ Layout Tab - Drag & Drop ============
 const layoutZones: { zone: LayoutZone; labelKey: 'topToolbar' | 'bottomStatusBar' | 'leftSidebar' | 'hiddenItems' }[] = [
@@ -321,7 +333,7 @@ onUnmounted(() => {
         <!-- Tab Navigation -->
         <div class="settings-tabs">
           <button
-            v-for="tab in (['appearance', 'editor', 'code', 'general', 'layout', 'ai'] as SettingsTab[])"
+            v-for="tab in (['appearance', 'editor', 'code', 'general', 'layout', 'ai', 'updates'] as SettingsTab[])"
             :key="tab"
             class="settings-tab"
             :class="{ active: activeTab === tab }"
@@ -361,10 +373,15 @@ onUnmounted(() => {
               <line x1="9" y1="9" x2="9" y2="21"/>
             </svg>
             <!-- AI icon -->
-            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg v-else-if="tab === 'ai'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
             </svg>
-            {{ tab === 'appearance' ? t.appearance : tab === 'editor' ? t.editor : tab === 'code' ? t.code : tab === 'general' ? t.general : tab === 'layout' ? t.layout : t.aiTabLabel }}
+            <!-- Updates icon -->
+            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/>
+              <polyline points="17 6 23 6 23 12"/>
+            </svg>
+            {{ tab === 'appearance' ? t.appearance : tab === 'editor' ? t.editor : tab === 'code' ? t.code : tab === 'general' ? t.general : tab === 'layout' ? t.layout : tab === 'ai' ? t.aiTabLabel : t.updatesTab }}
           </button>
         </div>
 
@@ -741,8 +758,10 @@ onUnmounted(() => {
               </div>
             </div>
 
-            <div class="setting-divider"></div>
+          </div>
 
+          <!-- Updates Tab -->
+          <div v-if="activeTab === 'updates'" class="settings-section">
             <div class="setting-row">
               <label class="setting-label">Version</label>
               <div class="setting-control version-control">
@@ -752,6 +771,63 @@ onUnmounted(() => {
                 </button>
               </div>
             </div>
+
+            <div class="setting-divider"></div>
+
+            <div class="setting-row">
+              <label class="setting-label">{{ t.updatesTab }}</label>
+              <div class="setting-control update-check-control">
+                <button
+                  class="update-check-btn"
+                  :disabled="isCheckingForUpdates || isUpdating"
+                  @click="checkForUpdatesManual()"
+                >
+                  <svg v-if="!isCheckingForUpdates" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="1 4 1 10 7 10"/>
+                    <path d="M3.51 15a9 9 0 1 0 .49-4"/>
+                  </svg>
+                  <svg v-else class="spin" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <line x1="12" y1="2" x2="12" y2="6"/>
+                    <line x1="12" y1="18" x2="12" y2="22"/>
+                    <line x1="4.93" y1="4.93" x2="7.76" y2="7.76"/>
+                    <line x1="16.24" y1="16.24" x2="19.07" y2="19.07"/>
+                    <line x1="2" y1="12" x2="6" y2="12"/>
+                    <line x1="18" y1="12" x2="22" y2="12"/>
+                    <line x1="4.93" y1="19.07" x2="7.76" y2="16.24"/>
+                    <line x1="16.24" y1="7.76" x2="19.07" y2="4.93"/>
+                  </svg>
+                  {{ isCheckingForUpdates ? t.checkingForUpdates : t.checkForUpdates }}
+                </button>
+                <span v-if="noUpdateFound && !isCheckingForUpdates && !updateInfo" class="update-status up-to-date">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="20 6 9 17 4 12"/>
+                  </svg>
+                  {{ t.upToDate }}
+                </span>
+                <span v-if="updateInfo && !isUpdating" class="update-status update-available">
+                  {{ t.newVersionAvailable }} v{{ updateInfo.version }}
+                </span>
+              </div>
+            </div>
+
+            <div v-if="updateInfo" class="setting-row update-install-row">
+              <label class="setting-label"></label>
+              <div class="setting-control">
+                <button
+                  class="update-now-btn"
+                  :disabled="isUpdating"
+                  @click="downloadAndInstallUpdate()"
+                >
+                  {{ isUpdating ? t.updating : t.updateNow }}
+                </button>
+                <div v-if="isUpdating" class="update-progress-bar">
+                  <div class="update-progress-fill" :style="{ width: updateProgress + '%' }"></div>
+                </div>
+                <span v-if="updateError" class="update-error">{{ updateError }}</span>
+              </div>
+            </div>
+
+            <div class="setting-divider"></div>
 
             <div class="setting-row">
               <label class="setting-label">{{ t.supportDev }}</label>
@@ -924,8 +1000,9 @@ onUnmounted(() => {
 /* Tabs */
 .settings-tabs {
   display: flex;
+  flex-wrap: wrap;
   gap: 0;
-  padding: 0 16px;
+  padding: 0 8px;
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
 }
@@ -933,8 +1010,8 @@ onUnmounted(() => {
 .settings-tab {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 10px 16px;
+  gap: 5px;
+  padding: 9px 11px;
   border: none;
   background: transparent;
   color: var(--text-muted);
@@ -1157,6 +1234,104 @@ onUnmounted(() => {
 }
 .bmc-link svg {
   flex-shrink: 0;
+}
+
+/* Updates Tab */
+.update-check-control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.update-check-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: 5px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.update-check-btn:hover:not(:disabled) {
+  background: var(--hover-bg);
+  border-color: var(--primary);
+}
+.update-check-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.update-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+}
+.update-status.up-to-date {
+  color: #16a34a;
+}
+html.dark .update-status.up-to-date {
+  color: #4ade80;
+}
+.update-status.update-available {
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.update-install-row .setting-control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.update-now-btn {
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--primary);
+  border-radius: 5px;
+  background: var(--primary);
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.update-now-btn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.update-progress-bar {
+  flex: 1;
+  min-width: 80px;
+  max-width: 160px;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.update-progress-fill {
+  height: 100%;
+  background: var(--primary);
+  border-radius: 2px;
+  transition: width 0.2s ease;
+}
+
+.update-error {
+  font-size: 11px;
+  color: var(--danger);
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.spin {
+  animation: spin 0.9s linear infinite;
 }
 
 /* Layout Tab */

--- a/src/composables/useAutoUpdate.ts
+++ b/src/composables/useAutoUpdate.ts
@@ -11,13 +11,25 @@ export interface UseAutoUpdateReturn {
   updateProgress: ReturnType<typeof ref<number>>;
   isUpdating: ReturnType<typeof ref<boolean>>;
   updateError: ReturnType<typeof ref<string | null>>;
+  isCheckingForUpdates: ReturnType<typeof ref<boolean>>;
+  noUpdateFound: ReturnType<typeof ref<boolean>>;
   checkForUpdates: () => Promise<void>;
+  checkForUpdatesManual: () => Promise<void>;
   downloadAndInstallUpdate: () => Promise<void>;
   closeUpdateDialog: () => void;
 }
 
 const DISMISSED_KEY = 'mermark-dismissed-update-version';
 const GITHUB_REPO = 'Vesperino/MerMarkEditor';
+
+// Module-level singletons so App.vue and SettingsModal share the same state.
+const showUpdateDialog = ref(false);
+const updateInfo = ref<UpdateInfo | null>(null);
+const updateProgress = ref(0);
+const isUpdating = ref(false);
+const updateError = ref<string | null>(null);
+const isCheckingForUpdates = ref(false);
+const noUpdateFound = ref(false);
 
 /** Fetch release notes from GitHub API as fallback when Tauri updater body is empty. */
 async function fetchGitHubReleaseNotes(version: string): Promise<string> {
@@ -32,34 +44,40 @@ async function fetchGitHubReleaseNotes(version: string): Promise<string> {
   }
 }
 
-export function useAutoUpdate(): UseAutoUpdateReturn {
-  const showUpdateDialog = ref(false);
-  const updateInfo = ref<UpdateInfo | null>(null);
-  const updateProgress = ref(0);
-  const isUpdating = ref(false);
-  const updateError = ref<string | null>(null);
+async function runCheck(ignoreDismissed: boolean): Promise<void> {
+  noUpdateFound.value = false;
+  isCheckingForUpdates.value = true;
+  try {
+    const { check } = await import('@tauri-apps/plugin-updater');
+    const update = await check();
 
-  const checkForUpdates = async (): Promise<void> => {
-    try {
-      const { check } = await import('@tauri-apps/plugin-updater');
-      const update = await check();
-      if (!update) return;
-
-      // Skip if user already dismissed this exact version
-      if (localStorage.getItem(DISMISSED_KEY) === update.version) return;
-
-      // Prefer Tauri updater body; fall back to GitHub Releases API
-      let notes = update.body || '';
-      if (!notes.trim()) {
-        notes = await fetchGitHubReleaseNotes(update.version);
-      }
-
-      updateInfo.value = { version: update.version, notes };
-      showUpdateDialog.value = true;
-    } catch (error) {
-      console.log('Update check skipped:', error);
+    if (!update) {
+      if (ignoreDismissed) noUpdateFound.value = true;
+      return;
     }
-  };
+
+    // Skip if user already dismissed this exact version (automatic check only)
+    if (!ignoreDismissed && localStorage.getItem(DISMISSED_KEY) === update.version) return;
+
+    // Prefer Tauri updater body; fall back to GitHub Releases API
+    let notes = update.body || '';
+    if (!notes.trim()) {
+      notes = await fetchGitHubReleaseNotes(update.version);
+    }
+
+    updateInfo.value = { version: update.version, notes };
+    showUpdateDialog.value = true;
+  } catch (error) {
+    console.log('Update check skipped:', error);
+    if (ignoreDismissed) noUpdateFound.value = true;
+  } finally {
+    isCheckingForUpdates.value = false;
+  }
+}
+
+export function useAutoUpdate(): UseAutoUpdateReturn {
+  const checkForUpdates = (): Promise<void> => runCheck(false);
+  const checkForUpdatesManual = (): Promise<void> => runCheck(true);
 
   const downloadAndInstallUpdate = async (): Promise<void> => {
     try {
@@ -101,7 +119,7 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
 
   const closeUpdateDialog = (): void => {
     if (isUpdating.value) return;
-    // Persist dismissal so the dialog doesn't reappear for this version (fixes HMR/remount loop)
+    // Persist dismissal so the dialog doesn't reappear for this version
     if (updateInfo.value?.version) {
       localStorage.setItem(DISMISSED_KEY, updateInfo.value.version);
     }
@@ -116,7 +134,10 @@ export function useAutoUpdate(): UseAutoUpdateReturn {
     updateProgress,
     isUpdating,
     updateError,
+    isCheckingForUpdates,
+    noUpdateFound,
     checkForUpdates,
+    checkForUpdatesManual,
     downloadAndInstallUpdate,
     closeUpdateDialog,
   };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -205,6 +205,10 @@ export interface Translations {
   supportDev: string;
   supportDevTooltip: string;
   buyMeACoffee: string;
+  updatesTab: string;
+  checkForUpdates: string;
+  checkingForUpdates: string;
+  upToDate: string;
 
   // Split view / Panes
   dragTabHere: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -199,6 +199,10 @@ const en: Translations = {
   supportDev: 'Support development',
   supportDevTooltip: 'MerMark is free and open source. If it helps you, you can buy me a coffee — totally optional.',
   buyMeACoffee: 'Buy me a coffee',
+  updatesTab: 'Updates',
+  checkForUpdates: 'Check for updates',
+  checkingForUpdates: 'Checking...',
+  upToDate: "You're up to date",
 
   // Split view / Panes
   dragTabHere: 'Drag tab here',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -199,6 +199,10 @@ const pl: Translations = {
   supportDev: 'Wesprzyj rozwój',
   supportDevTooltip: 'MerMark jest darmowy i open source. Jeśli ci pomaga, możesz postawić mi kawę — całkowicie opcjonalnie.',
   buyMeACoffee: 'Postaw mi kawę',
+  updatesTab: 'Aktualizacje',
+  checkForUpdates: 'Sprawdź aktualizacje',
+  checkingForUpdates: 'Sprawdzam...',
+  upToDate: 'Masz najnowszą wersję',
 
   // Split view / Panes
   dragTabHere: 'Przeciągnij kartę tutaj',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -199,6 +199,10 @@ const zhCN: Translations = {
   supportDev: '支持开发',
   supportDevTooltip: 'MerMark 免费且开源。如果它帮助到你，可以请我喝杯咖啡 — 完全自愿。',
   buyMeACoffee: '请我喝咖啡',
+  updatesTab: '更新',
+  checkForUpdates: '检查更新',
+  checkingForUpdates: '正在检查...',
+  upToDate: '已是最新版本',
 
   // Split view / Panes
   dragTabHere: '将标签页拖放至此',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -462,8 +462,14 @@ button:disabled {
 @media print {
   /* Force a calm, neutral light palette so every `var()` reference inside
      content resolves to a print-friendly value regardless of light/dark/
-     minimal mode the user happens to be in. */
-  html, html.dark {
+     minimal mode the user happens to be in.
+     All four variants must be listed: html[data-variant="minimal"] has higher
+     specificity than plain `html`, so without explicit entries here the
+     minimal.css token values (e.g. low-contrast --border-primary) would win
+     and produce nearly-invisible table borders in PDF output. */
+  html, html.dark,
+  html[data-variant="minimal"],
+  html.dark[data-variant="minimal"] {
     --bg-primary: #ffffff;
     --bg-secondary: #fafafa;
     --bg-tertiary: #f4f6f8;
@@ -928,6 +934,13 @@ button:disabled {
   pre .hljs-params,
   pre code .hljs-params { color: #abb2bf !important; -webkit-text-fill-color: #abb2bf !important; }
 
+  /* TipTap wraps tables in .tableWrapper with overflow-x: auto for the
+     editor UX — in print that clips columns that extend near the margin. */
+  .tableWrapper {
+    overflow: visible !important;
+    max-width: 100% !important;
+  }
+
   /* ===== Tables =====
      Long tables split across pages with the header repeating, individual
      rows stay together. Zebra rows on the body for scanability. Header gets
@@ -1079,8 +1092,12 @@ button:disabled {
 
   .mermaid-content svg,
   .mermaid-viewport svg {
+    /* Override inline width set by applySvgSize() — in print the diagram
+       must fit the page regardless of the user's on-screen size preference. */
+    width: 100% !important;
     max-width: 100% !important;
     height: auto !important;
+    display: block !important;
   }
 
   /* Images get a subtle frame + caption-friendly margins; never cropped. */


### PR DESCRIPTION
## Summary

- **PDF/print: Mermaid diagrams clipped at right edge** — `display:flex` on `.mermaid-content` let the flex container expand past the page content area; inline `width` from `applySvgSize()` was not overridden in print. Fixed: switch to `display:block`, add `width:100%!important` to both global and scoped SVG print rules.
- **PDF/print: Table borders invisible in Minimal theme** — print palette reset only targeted `html, html.dark`; `html[data-variant="minimal"]` has higher CSS specificity so `--border-primary` from `minimal.css` was winning (low-contrast on white). Fixed: add both minimal variants to the reset selector.
- **PDF/print: Table columns clipped** — TipTap wraps tables in `.tableWrapper { overflow-x: auto }` which clips in print. Fixed: `overflow:visible!important` on `.tableWrapper` in `@media print`.
- **Settings > Updates tab** (closes #82) — new tab with manual "Check for updates" button, "You're up to date" feedback, inline progress bar and "Update Now" when an update is found. Version and Support Development rows moved here from General. `useAutoUpdate` refactored to module-level singleton so Settings and App.vue share state without prop drilling.
- **Tab bar wraps** — `flex-wrap:wrap` so all 7 tabs are always reachable regardless of window width.
- v0.2.8 release notes archived to `docs/release-notes/v0.2.8/`.

## Test plan

- [x] Export a document with a wide Mermaid flowchart to PDF — diagram fits page, no right-edge clipping
- [x] Export with a multi-column table in Minimal theme — borders visible, columns not clipped
- [x] Settings → Updates tab visible and accessible
- [x] "Check for updates" shows spinner → "You're up to date" or update prompt
- [x] If update available: "Update Now" button + progress bar work
- [x] Settings tab bar wraps on narrow window without hiding tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)