### PR TITLE
fix: PDF export — respect diagram size and hide split pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ line-numbers-*.png
 
 # AI staging tmp files (sit next to docs during apply)
 *.mermark-ai.tmp
+.worktrees/

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
-# Release v0.2.11 — Mermaid diagram fix
+# Release v0.2.12 — PDF fixes
 
 ## Bug fixes
 
-- **Mermaid diagrams no longer clip node content** — nodes with multi-line labels are now fully visible in the editor, preview pane, and PDF export.
-
+- **PDF export now respects diagram size** — diagrams set to a smaller size are no longer stretched to full page width in the exported PDF.
+- **Split view no longer duplicates content in PDF** — only the active (left) pane is printed when the editor is in split mode.

--- a/src/components/MermaidNode.vue
+++ b/src/components/MermaidNode.vue
@@ -68,11 +68,14 @@ const MAX_USER_WIDTH = 1600;
 const userWidth = computed(() => props.node.attrs.userWidth);
 
 const wrapperStyle = computed(() => {
-  if (!userWidth.value) return undefined;
-  return {
-    width: `${userWidth.value}px`,
-    maxWidth: '100%',
-  } as Record<string, string>;
+  const style: Record<string, string> = {
+    '--diagram-print-scale': `${diagramSize.value}%`,
+  };
+  if (userWidth.value) {
+    style.width = `${userWidth.value}px`;
+    style.maxWidth = '100%';
+  }
+  return style;
 });
 
 let resizeStartX = 0;
@@ -1582,11 +1585,13 @@ html.dark .mermaid-content :deep(svg .messageLine1) {
      slightly undersized after the getBBox() adjustment, content won't
      be hard-clipped by the SVG viewport. */
   .mermaid-content :deep(svg) {
-    width: 100% !important;
-    max-width: 100% !important;
+    width: var(--diagram-print-scale, 100%) !important;
+    max-width: var(--diagram-print-scale, 100%) !important;
     height: auto !important;
     overflow: visible !important;
     background: white !important;
+    display: block !important;
+    margin: 0 auto !important;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1092,12 +1092,11 @@ button:disabled {
 
   .mermaid-content svg,
   .mermaid-viewport svg {
-    /* Override inline width set by applySvgSize() — in print the diagram
-       must fit the page regardless of the user's on-screen size preference. */
-    width: 100% !important;
-    max-width: 100% !important;
+    width: var(--diagram-print-scale, 100%) !important;
+    max-width: var(--diagram-print-scale, 100%) !important;
     height: auto !important;
     display: block !important;
+    margin: 0 auto !important;
   }
 
   /* Images get a subtle frame + caption-friendly margins; never cropped. */
@@ -1118,6 +1117,11 @@ button:disabled {
     max-height: none !important;
     overflow: visible !important;
     display: block !important;
+  }
+
+  /* In split view, print only the left (primary) pane. */
+  .editor-pane ~ .editor-pane {
+    display: none !important;
   }
 
   /* Allow page breaks inside very large mermaid diagrams when necessary */


### PR DESCRIPTION
## Summary

- Diagrams set to a smaller size (25/50/75%) are now respected in PDF — previously always forced to 100% page width
- In split view, only the left (primary) pane prints — previously both panes appeared in the PDF

## Test plan

- [ ] Set a diagram to 50%, export PDF, verify it renders at ~half page width and is centered
- [ ] Open two files in split view, export PDF, verify only the left pane content appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)