### PR TITLE
ci: integrate release workflow with /release-prep

### DIFF
--- a/.claude/skills/mermark-release-notes/SKILL.md
+++ b/.claude/skills/mermark-release-notes/SKILL.md
@@ -9,11 +9,15 @@ The MerMark repo keeps release notes in `docs/release-notes/vX.Y.Z/RELEASE_NOTES
 
 ## Critical context
 
-- **Tags trigger CI.** Pushing a `vX.Y.Z` git tag triggers GitHub Actions to build and publish the release. **Bump the version files BEFORE the tag is pushed.** That means the bump+notes commit lands on `master` first; the tag is pushed last.
+- **Push to `master` triggers CI.** `.github/workflows/release.yml` runs on every push to `master` and creates the GitHub release + tag automatically. Tag creation is a *side effect* of the workflow, not the trigger.
+- **Workflow has dual-mode behaviour.** It checks for `docs/release-notes/v${currentPackageVersion}/RELEASE_NOTES.md`:
+  - **Prepared mode (`/release-prep` was used):** the file exists → workflow skips its own bump, tags `v${currentPackageVersion}`, and publishes the release with `body_path` pointing at that file.
+  - **Legacy fallback:** the file is missing → workflow bumps patch +1, stubs the new notes file, commits, and publishes.
+- **Always run `/release-prep` before merging.** The legacy fallback is a safety net, not a happy path — the auto-stub release notes are placeholders and the bump may collide with the version the team intended.
 - **Current version = the latest published tag**, not whatever `package.json` says. `package.json` may already be ahead of the last tag if a previous release flow stopped mid-way. Always resolve via:
   1. `gh release list --limit 1 --json tagName --jq '.[0].tagName'`
   2. fallback `git describe --tags --abbrev=0`
-- The release-notes commit and the version-bump commit should be the **same commit** so reviewers see them together.
+- The release-notes commit and the version-bump commit produced by `bump-version.mjs` should be the **same commit** so reviewers see them together.
 
 ## Section convention
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,37 +30,75 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Bump version
-        id: version
+      # If the PR that landed already added docs/release-notes/v${current}/RELEASE_NOTES.md
+      # (i.e. the author ran /release-prep), the current package.json version is the
+      # release we want to publish — do not bump again, just tag and create the release.
+      # Otherwise fall back to the legacy auto-bump path so plain-PR merges keep working.
+      - name: Detect prepared release notes
+        id: notes
         run: |
           CURRENT="${{ steps.current_version.outputs.version }}"
-          # Split version into parts
+          FILE="docs/release-notes/v${CURRENT}/RELEASE_NOTES.md"
+          if [ -f "$FILE" ]; then
+            echo "prepared=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT" >> $GITHUB_OUTPUT
+            echo "body_path=$FILE" >> $GITHUB_OUTPUT
+            echo "Release notes already prepared at $FILE — skipping auto-bump."
+          else
+            echo "prepared=false" >> $GITHUB_OUTPUT
+            echo "No release notes folder for v${CURRENT}; will auto-bump and create a stub."
+          fi
+
+      - name: Bump version (legacy fallback)
+        id: bump
+        if: steps.notes.outputs.prepared == 'false'
+        run: |
+          CURRENT="${{ steps.current_version.outputs.version }}"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          # Increment patch version
           PATCH=$((PATCH + 1))
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "New version: $NEW_VERSION"
 
-      - name: Update version in package.json
+      - name: Update version files (legacy fallback)
+        if: steps.notes.outputs.prepared == 'false'
         run: |
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          NEW="${{ steps.bump.outputs.version }}"
+          npm version "$NEW" --no-git-tag-version
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW\"/" src-tauri/tauri.conf.json
+          sed -i "s/^version = \"[^\"]*\"/version = \"$NEW\"/" src-tauri/Cargo.toml
 
-      - name: Update version in tauri.conf.json
+      - name: Create release-notes stub (legacy fallback)
+        if: steps.notes.outputs.prepared == 'false'
         run: |
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.version.outputs.version }}"/' src-tauri/tauri.conf.json
+          NEW="${{ steps.bump.outputs.version }}"
+          DIR="docs/release-notes/v${NEW}"
+          mkdir -p "$DIR"
+          cat > "$DIR/RELEASE_NOTES.md" <<EOF
+          # Release v${NEW}
 
-      - name: Update version in Cargo.toml
-        run: |
-          sed -i 's/^version = "[^"]*"/version = "${{ steps.version.outputs.version }}"/' src-tauri/Cargo.toml
+          Auto-generated release. Edit \`${DIR}/RELEASE_NOTES.md\` to describe the changes.
+          EOF
 
-      - name: Commit version bump
+      - name: Commit version bump (legacy fallback)
+        if: steps.notes.outputs.prepared == 'false'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml
-          git commit -m "chore: bump version to ${{ steps.version.outputs.version }}"
+          git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml \
+                  docs/release-notes/v${{ steps.bump.outputs.version }}/RELEASE_NOTES.md
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
           git push
+
+      - name: Resolve release version
+        id: version
+        run: |
+          if [ "${{ steps.notes.outputs.prepared }}" = "true" ]; then
+            echo "version=${{ steps.notes.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "body_path=${{ steps.notes.outputs.body_path }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.bump.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "body_path=docs/release-notes/v${{ steps.bump.outputs.version }}/RELEASE_NOTES.md" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Release
         id: create_release
@@ -68,7 +106,7 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: MerMark Editor v${{ steps.version.outputs.version }}
-          body_path: RELEASE_NOTES.md
+          body_path: ${{ steps.version.outputs.body_path }}
           draft: false
           prerelease: false
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.2.15",
+  "version": "0.2.14",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.2.15"
+version = "0.2.14"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.2.15",
+  "version": "0.2.14",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- **Workflow detects prepared release notes.** `.github/workflows/release.yml` now checks for `docs/release-notes/v${currentVersion}/RELEASE_NOTES.md`. If the file exists (because the PR author ran `/release-prep`), the workflow skips its own bump, tags `v${currentVersion}`, and uses the prepared file as the release body. If the file is missing it falls back to the legacy bump-+1 path and auto-stubs a notes file — so plain PRs without `/release-prep` still ship.
- **Reverts the orphan v0.2.15 auto-bump** that the old workflow created when PR #87 merged. The old workflow bumped to 0.2.15, tried to read `RELEASE_NOTES.md` from the repo root (which #87 had migrated under `docs/release-notes/v0.2.12/`), failed, and never created the v0.2.15 release. Master is back to 0.2.14 with the notes I wrote in #87 still in place.
- **Skill description corrected** — push to `master` triggers CI, not the git tag. Skill now also documents the dual-mode workflow and why `/release-prep` is the preferred path.

## Why
The old workflow assumed every PR landing on master needed a bump + a release-notes file at the root. PR #87 moved release notes per-version, which made the workflow's `body_path: RELEASE_NOTES.md` step explode. The dual-mode change lets both flows coexist while we (and the rest of the team) migrate to `/release-prep`.

## Test plan
- [x] `pnpm vue-tsc --noEmit` — exit 0
- [x] `pnpm test:run` — 738 passing, 1 pre-existing `useAutoUpdate` failure unchanged
- [ ] On merge: workflow should detect `docs/release-notes/v0.2.14/RELEASE_NOTES.md`, skip the bump, tag `v0.2.14`, and create the GitHub release that PR #87 missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)