### PR TITLE
Release v0.5.0 — Code + Preview split (#94), accurate Claude context meter (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ---
 
+# Release v0.5.0 — Code + Preview split editor, accurate Claude context meter
+
+Write Markdown and watch it render at the same time, and trust the AI context meter again. This release adds a side-by-side Code + Preview editor for the document you're working on, and fixes the Claude context-usage meter so it reflects what's actually in the window.
+
+## Features
+
+- **Code + Preview split.** Toggle "Code + Preview" in the toolbar to edit raw Markdown on the left and see the rendered result update live on the right — both showing the same document. Mermaid diagrams you change in the preview (by hand or with the AI button) flow back into the Markdown. (#94)
+
+## Bug fixes
+
+- **Claude context meter no longer over-reports.** A single reply could make it look like one turn ate ~100K tokens when the real context was a fraction of that. The meter now shows the true context size for the turn. (#99)
+
+---
+
 # Release v0.4.1 — Read and write multiple Mermaid fence styles
 
 ## Features

--- a/docs/release-notes/v0.5.0/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.5.0/RELEASE_NOTES.md
@@ -1,0 +1,11 @@
+# Release v0.5.0 — Code + Preview split editor, accurate Claude context meter
+
+Write Markdown and watch it render at the same time, and trust the AI context meter again. This release adds a side-by-side Code + Preview editor for the document you're working on, and fixes the Claude context-usage meter so it reflects what's actually in the window.
+
+## Features
+
+- **Code + Preview split.** Toggle "Code + Preview" in the toolbar to edit raw Markdown on the left and see the rendered result update live on the right — both showing the same document. Mermaid diagrams you change in the preview (by hand or with the AI button) flow back into the Markdown. (#94)
+
+## Bug fixes
+
+- **Claude context meter no longer over-reports.** A single reply could make it look like one turn ate ~100K tokens when the real context was a fraction of that. The meter now shows the true context size for the turn. (#99)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.4.1"
+version = "0.5.0"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/ai/process/normalizer.rs
+++ b/src-tauri/src/ai/process/normalizer.rs
@@ -16,6 +16,13 @@ pub struct CodexParserState {
 #[derive(Debug, Default)]
 pub struct ClaudeParserState {
     pub tools: HashMap<i64, ToolBuf>,
+    /// Usage snapshot of the LAST `assistant` message seen this turn. Each
+    /// tool-use round-trip is a separate API call with its own snapshot; the
+    /// final one reflects actual context-window occupancy. The `result`
+    /// event's top-level usage is the cumulative billing total summed across
+    /// every sub-call, which over-reports occupancy (cache_read is re-counted
+    /// per call), so we prefer this snapshot for the input-side fields.
+    pub last_assistant_usage: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Default)]
@@ -71,14 +78,29 @@ fn parse_claude_stateful(state: &mut ClaudeParserState, v: &serde_json::Value) -
         "system" => None,
         // Rate limit events — drop.
         "rate_limit_event" => None,
-        // Cumulative assistant snapshot — already streamed via deltas, drop.
-        "assistant" => None,
+        // The assistant message's content was already streamed via deltas, so
+        // we emit no chunk — but its `message.usage` is the per-API-call
+        // snapshot we need for the Done chunk, so remember the last one seen.
+        "assistant" => {
+            if let Some(u) = v.get("message").and_then(|m| m.get("usage")) {
+                state.last_assistant_usage = Some(u.clone());
+            }
+            None
+        }
         "stream_event" => parse_stream_event(state, v.get("event")?),
         "result" => {
             let session_id = v.get("session_id").and_then(|s| s.as_str()).unwrap_or("").to_string();
-            // Combine `usage` and `modelUsage` (which carries `contextWindow`)
-            // into a single payload so the frontend parser can read both.
-            let mut usage = v.get("usage").cloned().unwrap_or_else(|| serde_json::json!({}));
+            // Prefer the last assistant snapshot (per-call occupancy) over the
+            // result event's top-level usage (cumulative billing total). Fall
+            // back to the result usage for degenerate streams with no assistant
+            // event. Either way, merge `modelUsage` (which carries
+            // `contextWindow`, a sibling on the result event) so the frontend
+            // can lift the window.
+            let mut usage = state
+                .last_assistant_usage
+                .clone()
+                .or_else(|| v.get("usage").cloned())
+                .unwrap_or_else(|| serde_json::json!({}));
             if let Some(mu) = v.get("modelUsage").or_else(|| v.get("model_usage")) {
                 if let Some(obj) = usage.as_object_mut() {
                     obj.insert("modelUsage".to_string(), mu.clone());
@@ -320,10 +342,16 @@ mod tests {
     }
 
     #[test]
-    fn claude_assistant_event_is_dropped_with_partial_messages() {
-        // The cumulative assistant event would duplicate what we already streamed via deltas.
-        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]},"session_id":"s1"}"#;
-        assert!(parse_line_claude(&mut fresh_claude(), line).is_none());
+    fn claude_assistant_event_is_dropped_but_captures_usage() {
+        // Content was already streamed via deltas, so no chunk is emitted, but
+        // the per-call usage snapshot is captured for the Done chunk.
+        let mut state = fresh_claude();
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":3,"cache_read_input_tokens":100}},"session_id":"s1"}"#;
+        assert!(parse_line_claude(&mut state, line).is_none());
+        assert_eq!(
+            state.last_assistant_usage.as_ref().and_then(|u| u.get("cache_read_input_tokens")).and_then(|n| n.as_i64()),
+            Some(100)
+        );
     }
 
     #[test]
@@ -331,6 +359,64 @@ mod tests {
         let line = r#"{"type":"result","subtype":"success","result":"ok","session_id":"s2","duration_ms":2594}"#;
         match parse_line_claude(&mut fresh_claude(), line).unwrap() {
             AiResponseChunk::Done { session_id, .. } => assert_eq!(session_id, "s2"),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn claude_result_uses_last_assistant_usage_not_cumulative() {
+        let mut state = fresh_claude();
+        // Two sub-calls (tool-use round-trip). Each `assistant` event carries a
+        // per-call usage snapshot.
+        let call1 = r#"{"type":"assistant","message":{"usage":{"input_tokens":4,"cache_creation_input_tokens":0,"cache_read_input_tokens":5000,"output_tokens":12}}}"#;
+        let call2 = r#"{"type":"assistant","message":{"usage":{"input_tokens":6,"cache_creation_input_tokens":1000,"cache_read_input_tokens":30000,"output_tokens":40}}}"#;
+        assert!(parse_line_claude(&mut state, call1).is_none());
+        assert!(parse_line_claude(&mut state, call2).is_none());
+        // The result event carries the CUMULATIVE billing total (cache_read
+        // re-counted per sub-call → ~3x inflation).
+        let result = r#"{"type":"result","subtype":"success","session_id":"s3","usage":{"input_tokens":10,"cache_creation_input_tokens":1000,"cache_read_input_tokens":65000,"output_tokens":52}}"#;
+        match parse_line_claude(&mut state, result).unwrap() {
+            AiResponseChunk::Done { usage, .. } => {
+                let u = usage.unwrap();
+                assert_eq!(u.get("input_tokens").and_then(|n| n.as_i64()), Some(6));
+                assert_eq!(u.get("cache_creation_input_tokens").and_then(|n| n.as_i64()), Some(1000));
+                assert_eq!(u.get("cache_read_input_tokens").and_then(|n| n.as_i64()), Some(30000));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn claude_result_falls_back_to_result_usage_when_no_assistant_seen() {
+        let line = r#"{"type":"result","subtype":"success","session_id":"s4","usage":{"input_tokens":7,"cache_read_input_tokens":2000}}"#;
+        match parse_line_claude(&mut fresh_claude(), line).unwrap() {
+            AiResponseChunk::Done { usage, .. } => {
+                let u = usage.unwrap();
+                assert_eq!(u.get("input_tokens").and_then(|n| n.as_i64()), Some(7));
+                assert_eq!(u.get("cache_read_input_tokens").and_then(|n| n.as_i64()), Some(2000));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn claude_result_still_merges_model_usage_context_window() {
+        let mut state = fresh_claude();
+        let assistant = r#"{"type":"assistant","message":{"usage":{"input_tokens":6,"cache_read_input_tokens":30000}}}"#;
+        assert!(parse_line_claude(&mut state, assistant).is_none());
+        let result = r#"{"type":"result","subtype":"success","session_id":"s5","usage":{"input_tokens":10,"cache_read_input_tokens":90000},"modelUsage":{"claude-opus-4-8":{"contextWindow":200000}}}"#;
+        match parse_line_claude(&mut state, result).unwrap() {
+            AiResponseChunk::Done { usage, .. } => {
+                let u = usage.unwrap();
+                // input-side from the snapshot, contextWindow from result modelUsage.
+                assert_eq!(u.get("cache_read_input_tokens").and_then(|n| n.as_i64()), Some(30000));
+                let cw = u
+                    .get("modelUsage")
+                    .and_then(|m| m.get("claude-opus-4-8"))
+                    .and_then(|m| m.get("contextWindow"))
+                    .and_then(|n| n.as_i64());
+                assert_eq!(cw, Some(200000));
+            }
             _ => panic!("wrong variant"),
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ import LoadingOverlay from './components/LoadingOverlay.vue';
 import ExternalLinkDialog from './components/ExternalLinkDialog.vue';
 import UpdateDialog from './components/UpdateDialog.vue';
 import CodeEditor from './components/CodeEditor.vue';
+import Editor from './components/Editor.vue';
 import SaveConfirmDialog from './components/SaveConfirmDialog.vue';
 import SplitContainer from './components/SplitContainer.vue';
 import TabBar from './components/TabBar.vue';
@@ -38,6 +39,7 @@ import FileConflictModal from './components/FileConflictModal.vue';
 // Composables
 import { useAutoUpdate } from './composables/useAutoUpdate';
 import { useCodeView } from './composables/useCodeView';
+import { useSplitEditor } from './composables/useSplitEditor';
 import { useSettings } from './composables/useSettings';
 import { useSplitView } from './composables/useSplitView';
 import { useFileOperations } from './composables/useFileOperations';
@@ -193,7 +195,18 @@ const newFile = async () => {
   if (codeView.value) {
     await toggleCodeView();
   }
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  if (splitEditorActive.value && activeTab.value) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    activeTab.value.content = exitSplitEditor();
+    activeTab.value.hasChanges = true;
+  }
   createNewTab();
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  if (splitEditorActive.value) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    enterSplitEditor(activeTab.value?.content || '<p></p>');
+  }
 };
 
 // Find tab by file path across all panes
@@ -430,7 +443,15 @@ const {
   switchToTab,
   getEditorHtml: getEditorContent,
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  getMarkdownOverride: () => codeView.value ? codeContent.value : null,
+  getMarkdownOverride: () => {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    if (splitEditorActive.value) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      return splitSourceTabId.value === activeTabId.value ? splitMarkdownSource.value : null;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    return codeView.value ? codeContent.value : null;
+  },
   setEditorContent,
   markSaveStart: (filePath: string) => markSaveStart(filePath),
   markSaveEnd: (filePath: string, content: string) => markSaveEnd(filePath, content),
@@ -438,6 +459,13 @@ const {
     watchFile(filePath, content);
     const fileName = filePath.split(/[/\\]/).pop() ?? filePath;
     addRecentFile(filePath, fileName);
+    // Only the same-tab content-replacement case; tab-id changes are seeded by
+    // the activeTabId watch, and this tag guard avoids a double-seed race.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    if (splitEditorActive.value && splitSourceTabId.value === activeTabId.value) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      enterSplitEditor(activeTab.value?.content || '<p></p>');
+    }
   },
   onAfterSave: (filePath: string, content: string) => {
     // New file just got a path (Save / Save As on a fresh tab) — ensure
@@ -535,6 +563,98 @@ const toggleCodeView = async () => {
 
   await nextTick();
   isLoadingContent.value = false;
+};
+
+// ============ Split Editor (code + live preview of the same document) ============
+const {
+  splitEditorActive,
+  markdownSource: splitMarkdownSource,
+  previewHtml: splitPreviewHtml,
+  onMarkdownInput: onSplitMarkdownInput,
+  syncFromVisual: syncSplitFromVisual,
+  enter: enterSplitEditorRaw,
+  exit: exitSplitEditor,
+} = useSplitEditor();
+
+// Latest HTML emitted by the read-only preview editor. Committed back to the
+// code source only on a real in-preview edit (see onSplitPreviewChanged).
+const splitPreviewLatestHtml = ref('');
+
+// Tags splitMarkdownSource with the tab it was seeded from so the WRITE paths
+// can refuse to persist a source belonging to a different tab.
+const splitSourceTabId = ref<string | null>(null);
+
+const enterSplitEditor = (html: string): void => {
+  enterSplitEditorRaw(html);
+  splitSourceTabId.value = activeTabId.value;
+};
+
+// Single authoritative commit + re-seed for every active-tab change, covering
+// every open/switch path (cross-window already-open, focus listener, dropped
+// files, normal TabBar) uniformly.
+//
+// TIMING: nothing may overwrite splitMarkdownSource synchronously between the
+// activeTabId change and this flush, or the commit-old step would persist the
+// new edit into the old tab. This is why manual enter/exit seeding was removed
+// from switchToTabFromSplitEditor and onFileOpened.
+watch(activeTabId, (_newId, oldId) => {
+  if (!splitEditorActive.value) return;
+  if (splitSourceTabId.value === oldId) {
+    const oldIndex = tabs.value.findIndex(t => t.id === oldId);
+    if (oldIndex !== -1) {
+      tabs.value[oldIndex].content = markdownToHtml(splitMarkdownSource.value);
+      tabs.value[oldIndex].hasChanges = true;
+    }
+  }
+  enterSplitEditor(activeTab.value?.content || '<p></p>');
+});
+
+const toggleSplitEditor = async () => {
+  if (!splitEditorActive.value) {
+    if (codeView.value) {
+      await toggleCodeView();
+    }
+    // Read the live editor HTML so the latest (still-debounced) edit isn't lost
+    // when seeding the markdown source.
+    const html = editorInstance.value?.getHTML() ?? activeTab.value?.content ?? '<p></p>';
+    if (activeTab.value) {
+      activeTab.value.content = html;
+    }
+    isLoadingContent.value = true;
+    enterSplitEditor(html);
+    splitEditorActive.value = true;
+    await nextTick();
+    isLoadingContent.value = false;
+    return;
+  }
+
+  const html = exitSplitEditor();
+  if (activeTab.value) {
+    activeTab.value.content = html;
+    activeTab.value.hasChanges = true;
+  }
+  isLoadingContent.value = true;
+  splitEditorActive.value = false;
+  await nextTick();
+  isLoadingContent.value = false;
+};
+
+const handleSplitMarkdownInput = (value: string) => {
+  onSplitMarkdownInput(value);
+  if (activeTab.value) {
+    activeTab.value.hasChanges = true;
+  }
+};
+
+// Fires only for genuine in-preview edits (Mermaid diagram apply, manual node
+// edit) — the preview's setContent push suppresses hasChanges, so this never
+// echoes a code edit. Propagates the diagram change back into the code source.
+const onSplitPreviewChanged = (changed: boolean) => {
+  if (!changed || !splitEditorActive.value) return;
+  syncSplitFromVisual(splitPreviewLatestHtml.value);
+  if (activeTab.value) {
+    activeTab.value.hasChanges = true;
+  }
 };
 
 // ============ Current Document Search ============
@@ -659,6 +779,24 @@ const closeTabFromCodeView = async (tabId: string) => {
     await toggleCodeView();
   }
   handleCloseTabRequest(activePaneId.value, tabId);
+};
+
+const switchToTabFromSplitEditor = async (tabId: string) => {
+  if (tabId === activeTabId.value) return;
+  await switchToTab(tabId);
+};
+
+const closeTabFromSplitEditor = async (tabId: string) => {
+  if (tabId === activeTabId.value && activeTab.value && splitSourceTabId.value === tabId) {
+    activeTab.value.content = exitSplitEditor();
+    activeTab.value.hasChanges = true;
+  }
+  handleCloseTabRequest(activePaneId.value, tabId);
+  await nextTick();
+  if (splitEditorActive.value) {
+    enterSplitEditor(activeTab.value?.content || '<p></p>');
+    splitSourceTabId.value = activeTabId.value;
+  }
 };
 
 // ============ Diff Preview ============
@@ -1048,6 +1186,17 @@ const syncActiveTabContent = () => {
   // overwrite the real tab content.  Skip syncing in that case.
   if (codeView.value) return;
 
+  // Split-editor mode also unmounts SplitContainer; the editable markdown is
+  // the source of truth, so write it back as the tab's HTML content here.
+  if (splitEditorActive.value) {
+    if (splitSourceTabId.value !== activeTabId.value) return;
+    const tabIndex = tabs.value.findIndex(t => t.id === activeTabId.value);
+    if (tabIndex !== -1) {
+      tabs.value[tabIndex].content = markdownToHtml(splitMarkdownSource.value);
+    }
+    return;
+  }
+
   const currentContent = getEditorContent();
   const tabIndex = tabs.value.findIndex(t => t.id === activeTabId.value);
   if (tabIndex !== -1) {
@@ -1270,7 +1419,7 @@ const handleKeyboard = (event: KeyboardEvent) => {
         showSettingsModal.value = true;
         break;
       case 'v':
-        if (event.shiftKey) {
+        if (event.shiftKey && !splitEditorActive.value) {
           event.preventDefault();
           toggleCodeView();
         }
@@ -1554,6 +1703,7 @@ onUnmounted(async () => {
     <Toolbar
       :code-view="codeView"
       :is-split-active="isSplitActive"
+      :split-editor-active="splitEditorActive"
       :diff-active="showDiffPreview"
       :can-show-diff="canShowDiff"
       :can-compare-tabs="canCompareTabs"
@@ -1570,6 +1720,7 @@ onUnmounted(async () => {
       @export-docx="exportDocx"
       @toggle-code-view="toggleCodeView"
       @toggle-split="toggleSplit"
+      @toggle-split-editor="toggleSplitEditor"
       @toggle-diff-preview="toggleDiffPreview"
       @compare-tabs="compareTabs"
       @show-shortcuts="showShortcutsModal = true"
@@ -1619,8 +1770,36 @@ onUnmounted(async () => {
         @toggle-ai="toggleAiPanel"
       />
 
+      <!-- Code + Preview split: raw markdown (left) -> live WYSIWYG render (right) -->
+      <div v-if="splitEditorActive && !codeView" class="split-editor-area">
+        <TabBar
+          :tabs="tabs"
+          :active-tab-id="activeTabId"
+          :pane-id="activePaneId"
+          @switch-tab="switchToTabFromSplitEditor"
+          @close-tab="closeTabFromSplitEditor"
+        />
+        <div class="split-editor-panes">
+          <div class="split-editor-code">
+            <CodeEditor
+              :model-value="splitMarkdownSource"
+              @update:model-value="handleSplitMarkdownInput"
+            />
+          </div>
+          <div class="split-editor-preview">
+            <Editor
+              :model-value="splitPreviewHtml"
+              :file-path="activeTab?.filePath || null"
+              :editable="false"
+              @update:model-value="(h: string) => (splitPreviewLatestHtml = h)"
+              @update:has-changes="onSplitPreviewChanged"
+            />
+          </div>
+        </div>
+      </div>
+
       <!-- Editor area with optional TOC sidebar -->
-      <div v-if="!codeView" class="editor-area">
+      <div v-else-if="!codeView" class="editor-area">
         <!-- Table of Contents Panel -->
         <TableOfContents
           v-if="showTocPanel"
@@ -1667,6 +1846,7 @@ onUnmounted(async () => {
       v-if="hasStatusBarItems"
       :code-view="codeView"
       :is-split-active="isSplitActive"
+      :split-editor-active="splitEditorActive"
       :diff-active="showDiffPreview"
       :can-show-diff="canShowDiff"
       :can-compare-tabs="canCompareTabs"
@@ -1683,6 +1863,7 @@ onUnmounted(async () => {
       @export-docx="exportDocx"
       @toggle-code-view="toggleCodeView"
       @toggle-split="toggleSplit"
+      @toggle-split-editor="toggleSplitEditor"
       @toggle-diff-preview="toggleDiffPreview"
       @compare-tabs="compareTabs"
       @show-shortcuts="showShortcutsModal = true"
@@ -1908,6 +2089,40 @@ onUnmounted(async () => {
   flex: 1;
   overflow: hidden;
   min-height: 0;
+}
+
+.split-editor-area {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.split-editor-panes {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-editor-code,
+.split-editor-preview {
+  flex: 1 1 50%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.split-editor-code {
+  border-right: 1px solid var(--border-primary);
+}
+
+.split-editor-preview {
+  overflow-y: auto;
+  background: var(--editor-container-bg);
 }
 
 .drag-drop-overlay {

--- a/src/__tests__/composables/useAiContext.test.ts
+++ b/src/__tests__/composables/useAiContext.test.ts
@@ -42,4 +42,23 @@ describe('parseUsage', () => {
     });
     expect(u.fraction).toBe(1);
   });
+
+  it('reflects a single final-call snapshot as real occupancy (~30K, not cumulative)', () => {
+    // The normalizer hands parseUsage the LAST assistant message's per-call
+    // snapshot, not the cumulative result total. A ~30K turn must read ~30K.
+    const snapshot = parseUsage('claude', {
+      input_tokens: 6,
+      cache_creation_input_tokens: 1000,
+      cache_read_input_tokens: 30000,
+      output_tokens: 40,
+    });
+    expect(snapshot.totalInputTokens).toBe(6 + 1000 + 30000);
+    expect(snapshot.fraction).toBeLessThan(0.2);
+  });
+
+  it('keeps codex single-usage parsing unchanged', () => {
+    const u = parseUsage('codex', { input_tokens: 1 });
+    expect(u.totalInputTokens).toBe(1);
+    expect(u.contextWindow).toBe(256_000);
+  });
 });

--- a/src/__tests__/composables/useSplitEditor.test.ts
+++ b/src/__tests__/composables/useSplitEditor.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { nextTick } from 'vue';
+
+vi.mock('../../utils/markdown-converter', () => ({
+  markdownToHtml: (md: string) => `<p>HTML:${md}</p>`,
+  htmlToMarkdown: (html: string) => `MD:${html}`,
+}));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+});
+
+import { useSplitEditor } from '../../composables/useSplitEditor';
+
+describe('useSplitEditor', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('enter', () => {
+    it('seeds markdownSource from html and computes previewHtml from it', () => {
+      const { enter, markdownSource, previewHtml } = useSplitEditor();
+
+      enter('<p>hello</p>');
+
+      expect(markdownSource.value).toBe('MD:<p>hello</p>');
+      expect(previewHtml.value).toBe('<p>HTML:MD:<p>hello</p></p>');
+    });
+  });
+
+  describe('onMarkdownInput debounce', () => {
+    it('updates markdownSource immediately but previewHtml only after the debounce', () => {
+      vi.useFakeTimers();
+      try {
+        const { enter, onMarkdownInput, markdownSource, previewHtml } = useSplitEditor();
+
+        enter('<p>seed</p>');
+        const seededPreview = previewHtml.value;
+
+        onMarkdownInput('# edited');
+
+        expect(markdownSource.value).toBe('# edited');
+        expect(previewHtml.value).toBe(seededPreview);
+
+        vi.advanceTimersByTime(199);
+        expect(previewHtml.value).toBe(seededPreview);
+
+        vi.advanceTimersByTime(1);
+        expect(previewHtml.value).toBe('<p>HTML:# edited</p>');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('coalesces rapid edits into a single preview update', () => {
+      vi.useFakeTimers();
+      try {
+        const { enter, onMarkdownInput, previewHtml } = useSplitEditor();
+        enter('<p>seed</p>');
+
+        onMarkdownInput('a');
+        vi.advanceTimersByTime(100);
+        onMarkdownInput('ab');
+        vi.advanceTimersByTime(100);
+        onMarkdownInput('abc');
+        vi.advanceTimersByTime(200);
+
+        expect(previewHtml.value).toBe('<p>HTML:abc</p>');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('syncFromVisual (in-preview node edit -> code)', () => {
+    it('updates markdownSource from preview html without re-pushing previewHtml', () => {
+      const { enter, syncFromVisual, markdownSource, previewHtml } = useSplitEditor();
+
+      enter('<p>seed</p>');
+      const seededPreview = previewHtml.value;
+
+      syncFromVisual('<p>edited diagram</p>');
+
+      expect(markdownSource.value).toBe('MD:<p>edited diagram</p>');
+      expect(previewHtml.value).toBe(seededPreview);
+    });
+
+    it('skips when converted markdown equals the current source (echo guard)', () => {
+      const { enter, syncFromVisual, markdownSource } = useSplitEditor();
+
+      enter('<p>seed</p>');
+      syncFromVisual('<p>same</p>');
+      syncFromVisual('<p>same</p>');
+
+      expect(markdownSource.value).toBe('MD:<p>same</p>');
+    });
+  });
+
+  describe('exit (no data loss)', () => {
+    it('round-trips enter(html) -> exit() through the converters without edits', () => {
+      const { enter, exit } = useSplitEditor();
+
+      enter('<p>doc</p>');
+      const html = exit();
+
+      expect(html).toBe('<p>HTML:MD:<p>doc</p></p>');
+    });
+
+    it('returns the edited markdown converted to html', () => {
+      const { enter, onMarkdownInput, exit } = useSplitEditor();
+
+      enter('<p>doc</p>');
+      onMarkdownInput('## new heading');
+      const html = exit();
+
+      expect(html).toBe('<p>HTML:## new heading</p>');
+    });
+
+    it('flushes a pending debounce so previewHtml reflects the final edit', () => {
+      vi.useFakeTimers();
+      try {
+        const { enter, onMarkdownInput, exit, previewHtml } = useSplitEditor();
+        enter('<p>doc</p>');
+        onMarkdownInput('pending edit');
+
+        exit();
+
+        expect(previewHtml.value).toBe('<p>HTML:pending edit</p>');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('tagged-source invariant (no wrong-tab write)', () => {
+    it('re-seeds cleanly so a source tagged for tab A is never read as tab B', () => {
+      const { enter, markdownSource } = useSplitEditor();
+
+      enter('<p>tab A</p>');
+      const tagA = 'A';
+
+      enter('<p>tab B</p>');
+      const tagB = 'B';
+
+      expect(markdownSource.value).toBe('MD:<p>tab B</p>');
+      expect(tagB).not.toBe(tagA);
+    });
+
+    it('models the WRITE-path guard: override is null when the tag mismatches the active tab', () => {
+      const { enter, markdownSource } = useSplitEditor();
+      enter('<p>tab A</p>');
+      const splitSourceTabId = 'A';
+
+      const getMarkdownOverride = (activeTabId: string) =>
+        splitSourceTabId === activeTabId ? markdownSource.value : null;
+
+      expect(getMarkdownOverride('A')).toBe('MD:<p>tab A</p>');
+      expect(getMarkdownOverride('B')).toBeNull();
+    });
+
+    it('models the sync guard: a tab whose id mismatches the tag is left untouched', () => {
+      const { enter, markdownSource } = useSplitEditor();
+      enter('<p>tab A</p>');
+      const splitSourceTabId = 'A';
+
+      const tabs: Record<string, string> = { A: '<p>A original</p>', B: '<p>B original</p>' };
+      const syncActiveTabContent = (activeTabId: string) => {
+        if (splitSourceTabId !== activeTabId) return;
+        tabs[activeTabId] = `HTML:${markdownSource.value}`;
+      };
+
+      syncActiveTabContent('B');
+      expect(tabs.B).toBe('<p>B original</p>');
+
+      syncActiveTabContent('A');
+      expect(tabs.A).toBe('HTML:MD:<p>tab A</p>');
+    });
+  });
+
+  describe('active flag (not persisted)', () => {
+    it('defaults to false even when localStorage holds a truthy value', () => {
+      localStorageMock.setItem('mermark-split-editor', 'true');
+
+      const { splitEditorActive } = useSplitEditor();
+
+      expect(splitEditorActive.value).toBe(false);
+    });
+
+    it('never writes the active flag to localStorage when toggled', async () => {
+      const { splitEditorActive } = useSplitEditor();
+
+      splitEditorActive.value = true;
+      await nextTick();
+
+      expect(localStorageMock.setItem).not.toHaveBeenCalledWith(
+        'mermark-split-editor',
+        expect.anything(),
+      );
+
+      splitEditorActive.value = false;
+    });
+  });
+});

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -370,10 +370,13 @@ const parseTextTable = (text: string): string | null => {
   return result;
 };
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   modelValue?: string;
   filePath?: string | null;
-}>();
+  editable?: boolean;
+}>(), {
+  editable: true,
+});
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
@@ -416,6 +419,7 @@ async function handlePastedImage(file: File): Promise<void> {
 
 const editor = useEditor({
   content: props.modelValue || `<p>${t.value.placeholder}</p>`,
+  editable: props.editable,
   // Resolve local image paths to blob URLs when the editor is first created.
   // This is essential because: (1) the watch on modelValue doesn't fire for the
   // initial value, and (2) onUpdate doesn't fire during initial content creation.
@@ -619,6 +623,13 @@ watch(
         emit("update:hasChanges", false);
       }, 200);
     }
+  }
+);
+
+watch(
+  () => props.editable,
+  (editable) => {
+    editor.value?.setEditable(editable);
   }
 );
 

--- a/src/components/LeftBar.vue
+++ b/src/components/LeftBar.vue
@@ -15,6 +15,7 @@ const leftBarItems = itemsForZone('leftbar');
 const props = defineProps<{
   codeView?: boolean;
   isSplitActive?: boolean;
+  splitEditorActive?: boolean;
   diffActive?: boolean;
   canShowDiff?: boolean;
   canCompareTabs?: boolean;
@@ -34,6 +35,7 @@ const emit = defineEmits<{
   exportDocx: [];
   toggleCodeView: [];
   toggleSplit: [];
+  toggleSplitEditor: [];
   toggleDiffPreview: [];
   compareTabs: [];
   showShortcuts: [];
@@ -56,6 +58,7 @@ const emit = defineEmits<{
         :expanded="settings.leftBarExpanded"
         :code-view="props.codeView"
         :is-split-active="props.isSplitActive"
+        :split-editor-active="props.splitEditorActive"
         :diff-active="props.diffActive"
         :can-show-diff="props.canShowDiff"
         :can-compare-tabs="props.canCompareTabs"
@@ -73,6 +76,7 @@ const emit = defineEmits<{
         @export-docx="emit('exportDocx')"
         @toggle-code-view="emit('toggleCodeView')"
         @toggle-split="emit('toggleSplit')"
+        @toggle-split-editor="emit('toggleSplitEditor')"
         @toggle-diff-preview="emit('toggleDiffPreview')"
         @compare-tabs="emit('compareTabs')"
         @show-shortcuts="emit('showShortcuts')"

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -12,6 +12,7 @@ const statusBarItems = itemsForZone('statusbar');
 const props = defineProps<{
   codeView?: boolean;
   isSplitActive?: boolean;
+  splitEditorActive?: boolean;
   diffActive?: boolean;
   canShowDiff?: boolean;
   canCompareTabs?: boolean;
@@ -31,6 +32,7 @@ const emit = defineEmits<{
   exportDocx: [];
   toggleCodeView: [];
   toggleSplit: [];
+  toggleSplitEditor: [];
   toggleDiffPreview: [];
   compareTabs: [];
   showShortcuts: [];
@@ -48,6 +50,7 @@ const emit = defineEmits<{
         compact
         :code-view="props.codeView"
         :is-split-active="props.isSplitActive"
+        :split-editor-active="props.splitEditorActive"
         :diff-active="props.diffActive"
         :can-show-diff="props.canShowDiff"
         :can-compare-tabs="props.canCompareTabs"
@@ -65,6 +68,7 @@ const emit = defineEmits<{
         @export-docx="emit('exportDocx')"
         @toggle-code-view="emit('toggleCodeView')"
         @toggle-split="emit('toggleSplit')"
+        @toggle-split-editor="emit('toggleSplitEditor')"
         @toggle-diff-preview="emit('toggleDiffPreview')"
         @compare-tabs="emit('compareTabs')"
         @show-shortcuts="emit('showShortcuts')"

--- a/src/components/Toolbar.vue
+++ b/src/components/Toolbar.vue
@@ -12,6 +12,7 @@ const toolbarItems = itemsForZone('toolbar');
 const props = defineProps<{
   codeView?: boolean;
   isSplitActive?: boolean;
+  splitEditorActive?: boolean;
   diffActive?: boolean;
   canShowDiff?: boolean;
   canCompareTabs?: boolean;
@@ -31,6 +32,7 @@ const emit = defineEmits<{
   exportDocx: [];
   toggleCodeView: [];
   toggleSplit: [];
+  toggleSplitEditor: [];
   toggleDiffPreview: [];
   compareTabs: [];
   showShortcuts: [];
@@ -77,6 +79,7 @@ const needsSpacerBefore = (index: number) => {
           :item-id="item.id"
           :code-view="props.codeView"
           :is-split-active="props.isSplitActive"
+          :split-editor-active="props.splitEditorActive"
           :diff-active="props.diffActive"
           :can-show-diff="props.canShowDiff"
           :can-compare-tabs="props.canCompareTabs"
@@ -94,6 +97,7 @@ const needsSpacerBefore = (index: number) => {
           @export-docx="emit('exportDocx')"
           @toggle-code-view="emit('toggleCodeView')"
           @toggle-split="emit('toggleSplit')"
+          @toggle-split-editor="emit('toggleSplitEditor')"
           @toggle-diff-preview="emit('toggleDiffPreview')"
           @compare-tabs="emit('compareTabs')"
           @show-shortcuts="emit('showShortcuts')"

--- a/src/components/ToolbarItemRenderer.vue
+++ b/src/components/ToolbarItemRenderer.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   expanded?: boolean;
   codeView?: boolean;
   isSplitActive?: boolean;
+  splitEditorActive?: boolean;
   diffActive?: boolean;
   canShowDiff?: boolean;
   canCompareTabs?: boolean;
@@ -35,6 +36,7 @@ const emit = defineEmits<{
   exportDocx: [];
   toggleCodeView: [];
   toggleSplit: [];
+  toggleSplitEditor: [];
   toggleDiffPreview: [];
   compareTabs: [];
   showShortcuts: [];
@@ -91,13 +93,15 @@ const needsEditor = (id: string) => {
 };
 
 const isDisabled = (id: string) => {
-  if (needsEditor(id) && props.codeView) return true;
+  if (needsEditor(id) && (props.codeView || props.splitEditorActive)) return true;
   if (id === 'undo') return !editor?.value?.can().undo();
   if (id === 'redo') return !editor?.value?.can().redo();
-  if (id === 'toggle-toc') return !!props.codeView;
-  if (id === 'toggle-split-view') return !!props.codeView;
-  if (id === 'toggle-diff') return !props.canShowDiff || !!props.codeView;
-  if (id === 'compare-tabs') return !props.canCompareTabs || !!props.codeView;
+  if (id === 'toggle-toc') return !!props.codeView || !!props.splitEditorActive;
+  if (id === 'toggle-code-view') return !!props.splitEditorActive;
+  if (id === 'toggle-split-view') return !!props.codeView || !!props.splitEditorActive;
+  if (id === 'toggle-split-editor') return !!props.isSplitActive;
+  if (id === 'toggle-diff') return !props.canShowDiff || !!props.codeView || !!props.splitEditorActive;
+  if (id === 'compare-tabs') return !props.canCompareTabs || !!props.codeView || !!props.splitEditorActive;
   return false;
 };
 
@@ -109,7 +113,7 @@ const showLabel = (id: string) => {
   const labelItems = [
     'new-file', 'open-file', 'save-file', 'save-file-as', 'export-pdf',
     'mermaid', 'footnote', 'toggle-toc', 'toggle-code-view', 'toggle-split-view',
-    'toggle-diff', 'compare-tabs',
+    'toggle-split-editor', 'toggle-diff', 'compare-tabs',
   ];
   return labelItems.includes(id);
 };
@@ -523,6 +527,17 @@ const showLabel = (id: string) => {
     <span v-if="showLabel(itemId)">{{ isSplitActive ? t.singleView : t.splitView }}</span>
   </button>
 
+  <button v-else-if="itemId === 'toggle-split-editor'" @click="emit('toggleSplitEditor')" :class="['toolbar-btn', 'split-editor-toggle-btn', { active: splitEditorActive, 'icon-only': !showLabel(itemId) }]" v-tooltip="splitEditorActive ? t.splitEditorExit : t.splitEditorTooltip" :disabled="isDisabled(itemId)">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="3" y="4" width="18" height="16" rx="2"/>
+      <line x1="12" y1="4" x2="12" y2="20"/>
+      <polyline points="6 9 8 12 6 15"/>
+      <line x1="15" y1="9" x2="19" y2="9"/>
+      <line x1="15" y1="13" x2="18" y2="13"/>
+    </svg>
+    <span v-if="showLabel(itemId)">{{ t.splitEditor }}</span>
+  </button>
+
   <button v-else-if="itemId === 'toggle-diff'" @click="emit('toggleDiffPreview')" :class="['toolbar-btn', 'changes-toggle-btn', { active: diffActive, 'icon-only': !showLabel(itemId) }]" v-tooltip="t.changes" :disabled="isDisabled(itemId)">
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/>
@@ -661,6 +676,11 @@ const showLabel = (id: string) => {
 .split-toggle-btn:hover:not(:disabled) { background: var(--split-toggle-hover-bg); border-color: var(--split-toggle-hover-border); }
 .split-toggle-btn.active { background: var(--split-toggle-active-bg); border-color: var(--split-toggle-active-border); color: white; }
 .split-toggle-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.split-editor-toggle-btn { background: var(--split-toggle-bg); border-color: var(--split-toggle-border); color: var(--split-toggle-color); }
+.split-editor-toggle-btn:hover:not(:disabled) { background: var(--split-toggle-hover-bg); border-color: var(--split-toggle-hover-border); }
+.split-editor-toggle-btn.active { background: var(--split-toggle-active-bg); border-color: var(--split-toggle-active-border); color: white; }
+.split-editor-toggle-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .changes-toggle-btn { background: var(--changes-toggle-bg); border-color: var(--changes-toggle-border); color: var(--changes-toggle-color); }
 .changes-toggle-btn:hover:not(:disabled) { background: var(--changes-toggle-hover-bg); border-color: var(--changes-toggle-hover-border); }

--- a/src/composables/useSplitEditor.ts
+++ b/src/composables/useSplitEditor.ts
@@ -1,0 +1,72 @@
+import { ref, computed, type Ref, type ComputedRef } from 'vue';
+import { htmlToMarkdown, markdownToHtml } from '../utils/markdown-converter';
+
+const PREVIEW_DEBOUNCE_MS = 200;
+
+const splitEditorActive = ref<boolean>(false);
+
+export interface UseSplitEditorReturn {
+  splitEditorActive: Ref<boolean>;
+  markdownSource: Ref<string>;
+  previewHtml: ComputedRef<string>;
+  enter: (html: string) => void;
+  exit: () => string;
+  onMarkdownInput: (value: string) => void;
+  syncFromVisual: (html: string) => void;
+}
+
+export function useSplitEditor(): UseSplitEditorReturn {
+  const markdownSource = ref('');
+  const debouncedSource = ref('');
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const previewHtml = computed(() => markdownToHtml(debouncedSource.value));
+
+  const enter = (html: string): void => {
+    const md = htmlToMarkdown(html);
+    markdownSource.value = md;
+    debouncedSource.value = md;
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  };
+
+  const exit = (): string => {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    debouncedSource.value = markdownSource.value;
+    return markdownToHtml(markdownSource.value);
+  };
+
+  const onMarkdownInput = (value: string): void => {
+    markdownSource.value = value;
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debouncedSource.value = markdownSource.value;
+      debounceTimer = null;
+    }, PREVIEW_DEBOUNCE_MS);
+  };
+
+  // Visual → code, for in-preview node edits only (e.g. editing a Mermaid
+  // diagram via AI/manual). Caller gates this on the preview editor's real-edit
+  // signal, so the code→visual push echo never reaches here. debouncedSource /
+  // previewHtml are left untouched so the preview isn't re-rendered mid-edit.
+  const syncFromVisual = (html: string): void => {
+    const md = htmlToMarkdown(html);
+    if (md === markdownSource.value) return;
+    markdownSource.value = md;
+  };
+
+  return {
+    splitEditorActive,
+    markdownSource,
+    previewHtml,
+    enter,
+    exit,
+    onMarkdownInput,
+    syncFromVisual,
+  };
+}

--- a/src/data/toolbarItems.ts
+++ b/src/data/toolbarItems.ts
@@ -92,6 +92,7 @@ export const TOOLBAR_ITEMS: ToolbarItemDef[] = [
   { id: 'toggle-toc', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1100, needsEditor: false, labelKey: 'tableOfContents' },
   { id: 'toggle-code-view', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1110, needsEditor: false, labelKey: 'codeView' },
   { id: 'toggle-split-view', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1120, needsEditor: false, labelKey: 'splitView' },
+  { id: 'toggle-split-editor', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1125, needsEditor: false, labelKey: 'splitEditor' },
   { id: 'toggle-diff', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1130, needsEditor: false, labelKey: 'changes' },
   { id: 'compare-tabs', category: 'view-toggles', defaultZone: 'toolbar', defaultOrder: 1140, needsEditor: false, labelKey: 'compareTabs' },
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -90,6 +90,11 @@ export interface Translations {
   splitView: string;
   singleView: string;
 
+  // Toolbar - Split Editor (code + live preview)
+  splitEditor: string;
+  splitEditorTooltip: string;
+  splitEditorExit: string;
+
   // Toolbar - Diff Preview
   changes: string;
   noChanges: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -84,6 +84,11 @@ const en: Translations = {
   splitView: 'Split',
   singleView: 'Single',
 
+  // Toolbar - Split Editor (code + live preview)
+  splitEditor: 'Code + Preview',
+  splitEditorTooltip: 'Code + Preview split: edit markdown on the left, see the rendered result on the right',
+  splitEditorExit: 'Exit Code + Preview',
+
   // Toolbar - Diff Preview
   changes: 'Changes',
   noChanges: 'No changes',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -84,6 +84,11 @@ const pl: Translations = {
   splitView: 'Podziel',
   singleView: 'Pojedynczy',
 
+  // Toolbar - Split Editor (code + live preview)
+  splitEditor: 'Kod + Podgląd',
+  splitEditorTooltip: 'Podział Kod + Podgląd: edytuj markdown po lewej, zobacz wynik po prawej',
+  splitEditorExit: 'Zamknij Kod + Podgląd',
+
   // Toolbar - Diff Preview
   changes: 'Zmiany',
   noChanges: 'Brak zmian',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -84,6 +84,11 @@ const zhCN: Translations = {
   splitView: '分屏',
   singleView: '单屏',
 
+  // Toolbar - Split Editor (code + live preview)
+  splitEditor: '代码 + 预览',
+  splitEditorTooltip: '代码 + 预览分屏：左侧编辑 markdown，右侧实时查看渲染结果',
+  splitEditorExit: '退出代码 + 预览',
+
   // Toolbar - Diff Preview
   changes: '更改',
   noChanges: '无更改',


### PR DESCRIPTION
## Release v0.5.0
Bundles two changes into one release (**supersedes #100 and #101**).

### Features
- **Code + Preview split editor** (#94) — edit Markdown on the left, live WYSIWYG on the right for the same document; in-preview Mermaid edits (manual or AI) sync back to the source. A tab-id-tagged source invariant prevents writing one tab's content into another (no data loss across tab switches, re-opens, dropped files); the split is not persisted across restarts.

### Bug fixes
- **Claude context meter** (#99) — reports the real per-turn context size (final API-call snapshot) instead of the cumulative sum across a turn's internal tool calls (~100K shown for a ~30K context → now accurate).

### Release
- Version 0.4.1 → 0.5.0; notes in `docs/release-notes/v0.5.0/`; `CHANGELOG.md` regenerated.

Verified locally: `vue-tsc` clean, vitest green, `cargo test` green (incl. new normalizer tests). No remote deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)