### PR TITLE
feat: synced code/preview scrolling + live Table of Contents (v0.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ---
 
+# Release v0.5.4 — Synced scrolling & live Table of Contents
+
+## Features
+
+- In the Code + Preview split, scrolling either pane now keeps the other roughly aligned, so the preview follows along while you edit the source.
+- The Table of Contents now highlights the section you are reading and updates automatically as you scroll through the document.
+
+---
+
 # Release v0.5.3 — Security updates
 
 ## Security

--- a/docs/release-notes/v0.5.4/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.5.4/RELEASE_NOTES.md
@@ -1,0 +1,6 @@
+# Release v0.5.4 — Synced scrolling & live Table of Contents
+
+## Features
+
+- In the Code + Preview split, scrolling either pane now keeps the other roughly aligned, so the preview follows along while you edit the source.
+- The Table of Contents now highlights the section you are reading and updates automatically as you scroll through the document.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.5.3"
+version = "0.5.4"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -629,7 +629,7 @@ const toggleSplitEditor = async () => {
     splitEditorActive.value = true;
     await nextTick();
     const codeEl = document.querySelector<HTMLElement>('#code-editor-textarea');
-    const previewEl = document.querySelector<HTMLElement>('.split-editor-preview');
+    const previewEl = document.querySelector<HTMLElement>('.split-editor-preview .editor-container');
     if (codeEl && previewEl) scrollSync.attach(codeEl, previewEl);
     isLoadingContent.value = false;
     return;

--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,7 @@ import FileConflictModal from './components/FileConflictModal.vue';
 import { useAutoUpdate } from './composables/useAutoUpdate';
 import { useCodeView } from './composables/useCodeView';
 import { useSplitEditor } from './composables/useSplitEditor';
+import { useScrollSync } from './composables/useScrollSync';
 import { useSettings } from './composables/useSettings';
 import { useSplitView } from './composables/useSplitView';
 import { useFileOperations } from './composables/useFileOperations';
@@ -576,6 +577,9 @@ const {
   exit: exitSplitEditor,
 } = useSplitEditor();
 
+// Proportional scroll-sync between the split code pane and the live preview.
+const scrollSync = useScrollSync();
+
 // Latest HTML emitted by the read-only preview editor. Committed back to the
 // code source only on a real in-preview edit (see onSplitPreviewChanged).
 const splitPreviewLatestHtml = ref('');
@@ -624,10 +628,14 @@ const toggleSplitEditor = async () => {
     enterSplitEditor(html);
     splitEditorActive.value = true;
     await nextTick();
+    const codeEl = document.querySelector<HTMLElement>('#code-editor-textarea');
+    const previewEl = document.querySelector<HTMLElement>('.split-editor-preview');
+    if (codeEl && previewEl) scrollSync.attach(codeEl, previewEl);
     isLoadingContent.value = false;
     return;
   }
 
+  scrollSync.detach();
   const html = exitSplitEditor();
   if (activeTab.value) {
     activeTab.value.content = html;
@@ -1664,6 +1672,7 @@ onMounted(async () => {
 onUnmounted(async () => {
   window.removeEventListener('keydown', handleKeyboard);
   window.removeEventListener('wheel', handleWheel);
+  scrollSync.detach();
   unwatchAll();
   if (unlistenOpenFile) {
     unlistenOpenFile();

--- a/src/__tests__/composables/useScrollSpy.test.ts
+++ b/src/__tests__/composables/useScrollSpy.test.ts
@@ -32,4 +32,19 @@ describe('pickActiveHeading', () => {
     ];
     expect(pickActiveHeading(tops, THRESHOLD)).toBe('a');
   });
+
+  it('returns the last heading when scrolled to the bottom, ignoring the threshold', () => {
+    // At the bottom the trailing headings can never reach the top threshold,
+    // so they would otherwise stay un-highlighted (#scrollspy bottom edge).
+    const tops = [
+      { id: 'a', top: -200 },
+      { id: 'b', top: 100 },
+      { id: 'c', top: 300 },
+    ];
+    expect(pickActiveHeading(tops, THRESHOLD, true)).toBe('c');
+  });
+
+  it('returns null at the bottom when there are no headings', () => {
+    expect(pickActiveHeading([], THRESHOLD, true)).toBeNull();
+  });
 });

--- a/src/__tests__/composables/useScrollSpy.test.ts
+++ b/src/__tests__/composables/useScrollSpy.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { pickActiveHeading } from '../../composables/useScrollSpy';
+
+describe('pickActiveHeading', () => {
+  const THRESHOLD = 80;
+
+  it('returns null when there are no headings', () => {
+    expect(pickActiveHeading([], THRESHOLD)).toBeNull();
+  });
+
+  it('returns the last heading at or above the threshold', () => {
+    const tops = [
+      { id: 'a', top: -100 },
+      { id: 'b', top: 40 },
+      { id: 'c', top: 300 },
+    ];
+    expect(pickActiveHeading(tops, THRESHOLD)).toBe('b');
+  });
+
+  it('returns the last heading when all are above the threshold', () => {
+    const tops = [
+      { id: 'a', top: -300 },
+      { id: 'b', top: -100 },
+    ];
+    expect(pickActiveHeading(tops, THRESHOLD)).toBe('b');
+  });
+
+  it('falls back to the first heading when all are below the threshold', () => {
+    const tops = [
+      { id: 'a', top: 200 },
+      { id: 'b', top: 500 },
+    ];
+    expect(pickActiveHeading(tops, THRESHOLD)).toBe('a');
+  });
+});

--- a/src/__tests__/composables/useScrollSync.test.ts
+++ b/src/__tests__/composables/useScrollSync.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { proportionalTarget } from '../../composables/useScrollSync';
+
+describe('proportionalTarget', () => {
+  it('maps the top of the source to the top of the destination', () => {
+    expect(proportionalTarget(0, 1000, 200, 2000, 200)).toBe(0);
+  });
+
+  it('maps the bottom of the source to the bottom of the destination', () => {
+    // srcMax = 800, dstMax = 1800, ratio = 1
+    expect(proportionalTarget(800, 1000, 200, 2000, 200)).toBe(1800);
+  });
+
+  it('maps the middle of the source proportionally', () => {
+    // srcMax = 800, srcTop 400 -> ratio 0.5, dstMax 1800 * 0.5 = 900
+    expect(proportionalTarget(400, 1000, 200, 2000, 200)).toBe(900);
+  });
+
+  it('returns 0 when the source has no scroll range', () => {
+    expect(proportionalTarget(0, 200, 200, 2000, 200)).toBe(0);
+    expect(proportionalTarget(50, 100, 200, 2000, 200)).toBe(0);
+  });
+
+  it('returns 0 when the destination has no scroll range', () => {
+    expect(proportionalTarget(400, 1000, 200, 200, 200)).toBe(0);
+  });
+
+  it('clamps a source position beyond its range', () => {
+    expect(proportionalTarget(99999, 1000, 200, 2000, 200)).toBe(1800);
+  });
+});

--- a/src/__tests__/composables/useScrollSync.test.ts
+++ b/src/__tests__/composables/useScrollSync.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { proportionalTarget } from '../../composables/useScrollSync';
+import { describe, it, expect, vi } from 'vitest';
+import { proportionalTarget, useScrollSync } from '../../composables/useScrollSync';
 
 describe('proportionalTarget', () => {
   it('maps the top of the source to the top of the destination', () => {
@@ -27,5 +27,25 @@ describe('proportionalTarget', () => {
 
   it('clamps a source position beyond its range', () => {
     expect(proportionalTarget(99999, 1000, 200, 2000, 200)).toBe(1800);
+  });
+});
+
+describe('useScrollSync attach/detach', () => {
+  it('adds scroll listeners on attach and removes them on detach', () => {
+    const code = document.createElement('div');
+    const preview = document.createElement('div');
+    const codeAdd = vi.spyOn(code, 'addEventListener');
+    const codeRemove = vi.spyOn(code, 'removeEventListener');
+    const previewAdd = vi.spyOn(preview, 'addEventListener');
+    const previewRemove = vi.spyOn(preview, 'removeEventListener');
+
+    const sync = useScrollSync();
+    sync.attach(code, preview);
+    expect(codeAdd).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+    expect(previewAdd).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+
+    sync.detach();
+    expect(codeRemove).toHaveBeenCalledWith('scroll', expect.any(Function));
+    expect(previewRemove).toHaveBeenCalledWith('scroll', expect.any(Function));
   });
 });

--- a/src/components/TableOfContents.vue
+++ b/src/components/TableOfContents.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, watch, onUnmounted, inject, type Ref } from 'vue';
+import { ref, computed, watch, onUnmounted, inject, nextTick, type Ref } from 'vue';
 import type { Editor } from '@tiptap/vue-3';
 import { useI18n } from '../i18n';
+import { SCROLL_OFFSET } from '../constants';
+import { pickActiveHeading } from '../composables/useScrollSpy';
 
 const { t } = useI18n();
 const editor = inject<Ref<Editor | null>>('editor');
@@ -99,6 +101,55 @@ const scrollToHeading = (item: TocItem) => {
   activeHeadingId.value = item.id;
 };
 
+// ── Scrollspy: highlight the heading of the current section while scrolling ──
+let scrollContainer: HTMLElement | null = null;
+let rafId = 0;
+
+const resolveHeadingEl = (item: TocItem): HTMLElement | null => {
+  if (!editor?.value || !scrollContainer) return null;
+  if (item.kind === 'footnotes') {
+    return scrollContainer.querySelector<HTMLElement>('.footnote-section-wrapper');
+  }
+  const { node } = editor.value.view.domAtPos(item.pos + 1);
+  return node instanceof HTMLElement ? node : node.parentElement;
+};
+
+const updateActiveHeading = () => {
+  if (!scrollContainer || headings.value.length === 0) return;
+  const containerTop = scrollContainer.getBoundingClientRect().top;
+  const tops = headings.value
+    .map((h) => {
+      const el = resolveHeadingEl(h);
+      return el ? { id: h.id, top: el.getBoundingClientRect().top - containerTop } : null;
+    })
+    .filter((t): t is { id: string; top: number } => t !== null);
+  activeHeadingId.value = pickActiveHeading(tops, SCROLL_OFFSET);
+};
+
+const onContainerScroll = () => {
+  if (rafId) return;
+  rafId = requestAnimationFrame(() => {
+    rafId = 0;
+    updateActiveHeading();
+  });
+};
+
+const detachScrollSpy = () => {
+  scrollContainer?.removeEventListener('scroll', onContainerScroll);
+  scrollContainer = null;
+  if (rafId) {
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
+};
+
+const attachScrollSpy = () => {
+  detachScrollSpy();
+  const dom = editor?.value?.view.dom as HTMLElement | undefined;
+  scrollContainer = (dom?.closest('.editor-container') as HTMLElement | null) ?? null;
+  scrollContainer?.addEventListener('scroll', onContainerScroll, { passive: true });
+};
+
 // Update headings on editor changes
 const onEditorUpdate = () => {
   extractHeadings();
@@ -110,10 +161,12 @@ watch(
   (newEditor, oldEditor) => {
     if (oldEditor) {
       oldEditor.off('update', onEditorUpdate);
+      detachScrollSpy();
     }
     if (newEditor) {
       newEditor.on('update', onEditorUpdate);
       extractHeadings();
+      nextTick(() => attachScrollSpy());
     }
   },
   { immediate: true }
@@ -123,6 +176,7 @@ onUnmounted(() => {
   if (editor?.value) {
     editor.value.off('update', onEditorUpdate);
   }
+  detachScrollSpy();
 });
 </script>
 

--- a/src/components/TableOfContents.vue
+++ b/src/components/TableOfContents.vue
@@ -123,7 +123,9 @@ const updateActiveHeading = () => {
       return el ? { id: h.id, top: el.getBoundingClientRect().top - containerTop } : null;
     })
     .filter((t): t is { id: string; top: number } => t !== null);
-  activeHeadingId.value = pickActiveHeading(tops, SCROLL_OFFSET);
+  const atBottom =
+    scrollContainer.scrollTop + scrollContainer.clientHeight >= scrollContainer.scrollHeight - 2;
+  activeHeadingId.value = pickActiveHeading(tops, SCROLL_OFFSET, atBottom);
 };
 
 const onContainerScroll = () => {

--- a/src/composables/useScrollSpy.ts
+++ b/src/composables/useScrollSpy.ts
@@ -7,9 +7,18 @@ export interface HeadingTop {
  * Pick the heading whose section the reader is currently in: the last heading
  * at or above the threshold. When the reader is scrolled above the first
  * heading, fall back to the first so something is always highlighted.
+ *
+ * `atBottom` forces the last heading: at the end of the document the trailing
+ * headings can never scroll up to the threshold, so without this they would
+ * stay un-highlighted.
  */
-export function pickActiveHeading(tops: HeadingTop[], threshold: number): string | null {
+export function pickActiveHeading(
+  tops: HeadingTop[],
+  threshold: number,
+  atBottom = false,
+): string | null {
   if (tops.length === 0) return null;
+  if (atBottom) return tops[tops.length - 1].id;
   let active: string | null = null;
   for (const h of tops) {
     if (h.top <= threshold) active = h.id;

--- a/src/composables/useScrollSpy.ts
+++ b/src/composables/useScrollSpy.ts
@@ -1,0 +1,18 @@
+export interface HeadingTop {
+  id: string;
+  top: number;
+}
+
+/**
+ * Pick the heading whose section the reader is currently in: the last heading
+ * at or above the threshold. When the reader is scrolled above the first
+ * heading, fall back to the first so something is always highlighted.
+ */
+export function pickActiveHeading(tops: HeadingTop[], threshold: number): string | null {
+  if (tops.length === 0) return null;
+  let active: string | null = null;
+  for (const h of tops) {
+    if (h.top <= threshold) active = h.id;
+  }
+  return active ?? tops[0].id;
+}

--- a/src/composables/useScrollSync.ts
+++ b/src/composables/useScrollSync.ts
@@ -15,3 +15,50 @@ export function proportionalTarget(
   const ratio = Math.min(Math.max(srcTop / srcMax, 0), 1);
   return ratio * dstMax;
 }
+
+export interface ScrollSync {
+  attach: (codeEl: HTMLElement, previewEl: HTMLElement) => void;
+  detach: () => void;
+}
+
+/**
+ * Bidirectional proportional scroll-sync between two scroll containers.
+ * A shared lock plus a requestAnimationFrame release prevents the programmatic
+ * scroll of one side from bouncing back through the other side's scroll event.
+ */
+export function useScrollSync(): ScrollSync {
+  let code: HTMLElement | null = null;
+  let preview: HTMLElement | null = null;
+  let lock = false;
+
+  const sync = (src: HTMLElement, dst: HTMLElement) => {
+    if (lock) return;
+    lock = true;
+    dst.scrollTop = proportionalTarget(
+      src.scrollTop, src.scrollHeight, src.clientHeight,
+      dst.scrollHeight, dst.clientHeight,
+    );
+    requestAnimationFrame(() => { lock = false; });
+  };
+
+  const onCodeScroll = () => { if (code && preview) sync(code, preview); };
+  const onPreviewScroll = () => { if (code && preview) sync(preview, code); };
+
+  const detach = () => {
+    code?.removeEventListener('scroll', onCodeScroll);
+    preview?.removeEventListener('scroll', onPreviewScroll);
+    code = null;
+    preview = null;
+    lock = false;
+  };
+
+  const attach = (codeEl: HTMLElement, previewEl: HTMLElement) => {
+    detach();
+    code = codeEl;
+    preview = previewEl;
+    code.addEventListener('scroll', onCodeScroll, { passive: true });
+    preview.addEventListener('scroll', onPreviewScroll, { passive: true });
+  };
+
+  return { attach, detach };
+}

--- a/src/composables/useScrollSync.ts
+++ b/src/composables/useScrollSync.ts
@@ -1,0 +1,17 @@
+/**
+ * Map a scroll position on one element to the equivalent proportional position
+ * on another. Returns 0 when either element has no scroll range.
+ */
+export function proportionalTarget(
+  srcTop: number,
+  srcScrollH: number,
+  srcClientH: number,
+  dstScrollH: number,
+  dstClientH: number,
+): number {
+  const srcMax = srcScrollH - srcClientH;
+  const dstMax = dstScrollH - dstClientH;
+  if (srcMax <= 0 || dstMax <= 0) return 0;
+  const ratio = Math.min(Math.max(srcTop / srcMax, 0), 1);
+  return ratio * dstMax;
+}


### PR DESCRIPTION
## Summary

Two scrolling UX features, each a small pure tested core plus thin DOM wiring that reuses existing state/selectors. No new dependencies.

- **Scroll-sync (Code + Preview split):** scrolling either pane keeps the other roughly aligned (bidirectional, proportional). A shared lock + `requestAnimationFrame` release prevents ping-pong feedback. `useScrollSync.ts` (`proportionalTarget` pure fn + `attach`/`detach`), wired into the split in `App.vue`.
- **TOC scrollspy:** the Table of Contents highlights the section you are reading and updates as you scroll. `useScrollSpy.ts` (`pickActiveHeading` pure fn) drives the existing `activeHeadingId`; rAF-throttled scroll listener in `TableOfContents.vue`.

## Fixes found during manual testing

- Scroll-sync targeted the wrong element (`.split-editor-preview` is only a flex wrapper); the real scroller is the inner `.editor-container`.
- Scrollspy stayed stuck on an earlier heading at the bottom of the document; now the last heading activates when scrolled to the end.

## Known limitation (by design)

- Sync is proportional, so a tall code block that renders short (e.g. a Mermaid diagram) can drift — "roughly aligned" is expected.
- Threshold scrollspy can't individually isolate a cluster of trailing headings that all share the last viewport (standard behaviour; matches GitHub/MDN).

## Tests

TDD throughout. New unit tests: `proportionalTarget` (ratio/clamp/zero-range), `pickActiveHeading` (threshold/fallback/bottom), `useScrollSync` attach/detach. Full suite: **871 passed**. `pnpm build` clean (vue-tsc).

## Test plan

- [ ] Split editor: scroll code → preview follows; scroll preview → code follows; no jitter; survives exit/re-enter.
- [ ] TOC: active section highlights while scrolling; footnotes entry; last heading highlights at the very bottom; click still works; tracks the active editor across tab/pane switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)