### PR TITLE
fix(linux): AppImage blank window — stop bundling stale libwayland-client (#106)

### DIFF
--- a/.github/workflows/appimage-smoke.yml
+++ b/.github/workflows/appimage-smoke.yml
@@ -1,0 +1,65 @@
+# Builds the Linux AppImage on PRs that touch packaging and asserts it does not
+# bundle libwayland-client.so.0 (stale copies break EGL on Mesa >= 24.2 hosts, #106).
+name: AppImage smoke
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - '.github/workflows/appimage-smoke.yml'
+      - 'src-tauri/**'
+
+jobs:
+  appimage-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
+
+      # Same pre-seed as release.yml — see the comment there (#106).
+      - name: Pre-seed linuxdeploy with fixed excludelist (#106)
+        run: |
+          mkdir -p ~/.cache/tauri
+          curl -fsSL --retry 3 -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage \
+            https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
+          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Build AppImage
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build --bundles appimage
+
+      - name: Assert AppImage bundles no libwayland-client (#106)
+        run: |
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name '*.AppImage' | head -1)
+          test -n "$APPIMAGE"
+          "$APPIMAGE" --appimage-extract > /dev/null
+          echo "=== bundled usr/lib ==="
+          find squashfs-root/usr/lib -maxdepth 1 -name '*.so*' -printf '%f\n' | sort
+          find squashfs-root/usr/lib -name 'libwebkit2gtk-4.1.so*' | grep -q . # sanity: extraction worked
+          if find squashfs-root/usr/lib -name 'libwayland-client.so*' | grep -q .; then
+            echo "::error::AppImage bundles libwayland-client.so.0 — breaks EGL on Mesa >= 24.2 hosts (#106)"
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,21 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev patchelf
 
+      # tauri-bundler downloads linuxdeploy from tauri-apps/binary-releases (built 2024-07-29,
+      # excludelist predates the libwayland-client.so.0 entry added 2024-11-03). That stale
+      # excludelist bundles noble's libwayland-client 1.22 into the AppImage; host Mesa >= 24.2
+      # needs wl_display_create_queue_with_name (wayland 1.23) -> EGL vendor load fails ->
+      # "Could not create default EGL display: EGL_BAD_PARAMETER" blank window (#106).
+      # The bundler skips the download when the file already sits in its tools cache, so we
+      # pre-seed a pinned upstream build whose compiled-in excludelist has the fix.
+      - name: Pre-seed linuxdeploy with fixed excludelist (#106)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          mkdir -p ~/.cache/tauri
+          curl -fsSL --retry 3 -o ~/.cache/tauri/linuxdeploy-x86_64.AppImage \
+            https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
+          chmod +x ~/.cache/tauri/linuxdeploy-x86_64.AppImage
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -166,3 +181,15 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           includeUpdaterJson: true
           args: ${{ matrix.args }}
+
+      - name: Assert AppImage bundles no libwayland-client (#106)
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          APPIMAGE=$(find src-tauri/target/release/bundle/appimage -name '*.AppImage' | head -1)
+          test -n "$APPIMAGE"
+          "$APPIMAGE" --appimage-extract > /dev/null
+          find squashfs-root/usr/lib -name 'libwebkit2gtk-4.1.so*' | grep -q . # sanity: extraction worked
+          if find squashfs-root/usr/lib -name 'libwayland-client.so*' | grep -q .; then
+            echo "::error::AppImage bundles libwayland-client.so.0 — breaks EGL on Mesa >= 24.2 hosts (#106)"
+            exit 1
+          fi

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -782,11 +782,13 @@ struct StartupEnvOverride {
     value: &'static str,
 }
 
-// WebKitGTK 2.42+ defaults to a DMA-BUF renderer that fails to create an EGL
-// display on several Linux GPU/driver stacks (NVIDIA, VMs, recent Mesa shipped
-// by Fedora and openSUSE Tumbleweed), leaving an empty window and aborting with
-// `Could not create default EGL display: EGL_BAD_PARAMETER` (#106). Forcing the
-// legacy, non-accelerated path restores rendering on those machines.
+// Helps with rendering glitches on fragile GPU stacks (NVIDIA, VMs) where EGL
+// itself works. NOTE: these vars cannot prevent the `Could not create default
+// EGL display: EGL_BAD_PARAMETER` abort from #106 — since WebKitGTK 2.46 the
+// WebProcess initializes its EGL display before the preference store is applied
+// (WebPage.cpp: drawingArea->updatePreferences runs ahead of updatePreferences),
+// so the abort is reachable regardless. The actual #106 fix is in release.yml:
+// the AppImage must not bundle libwayland-client.so.0.
 #[cfg(any(test, target_os = "linux"))]
 const LINUX_WEBKIT_RENDER_OVERRIDES: [StartupEnvOverride; 2] = [
     StartupEnvOverride { key: "WEBKIT_DISABLE_DMABUF_RENDERER", value: "1" },
@@ -816,7 +818,6 @@ fn apply_linux_webkit_overrides() {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Work around WebKitGTK's EGL/DMA-BUF abort before anything spawns (#106).
     #[cfg(target_os = "linux")]
     apply_linux_webkit_overrides();
 


### PR DESCRIPTION
## Root cause

The AppImage ships `libwayland-client.so.0` **1.22** (from the ubuntu-24.04 build runner). tauri-bundler downloads `linuxdeploy` from `tauri-apps/binary-releases` — a binary built **2024-07-29**, whose compiled-in excludelist predates the `libwayland-client.so.0` entry added upstream on **2024-11-03** ([pkg2appimage#559](https://github.com/AppImageCommunity/pkg2appimage/pull/559)) for exactly this failure.

At runtime: host Mesa ≥ 24.2 (`libEGL_mesa.so.0`) requires `wl_display_create_queue_with_name` (wayland 1.23+). The bundled WebKit loads the stale 1.22 copy first (`DT_NEEDED` + `RUNPATH=$ORIGIN`); ld.so SONAME dedup then binds the host EGL vendor to that copy → fatal symbol lookup (Fedora/openSUSE link with `BIND_NOW`) → glvnd has zero EGL vendors → `eglGetDisplay()` = `EGL_BAD_PARAMETER` → WebKit `CRASH()` in the WebProcess:

```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

Pure dynamic-linking failure, GPU-independent — hence identical on both reporter machines. `.deb`/`.rpm` unaffected (system webkit + system wayland). Same failure class previously hit rpi-imager, normcap, Cura, RPCS3.

## Why #107 didn't help

The `WEBKIT_DISABLE_DMABUF_RENDERER` / `WEBKIT_DISABLE_COMPOSITING_MODE` overrides are set correctly, but since WebKitGTK 2.46 (`WebPage.cpp`: `drawingArea->updatePreferences(store)` runs before `updatePreferences(store)`) the WebProcess initializes its EGL display **before** the preference store is applied — the abort is structurally unreachable by env vars. Verified against webkitgtk-2.52.3 sources (the version bundled in v0.5.4).

## Reproduced + fix verified (Fedora 44 container, same distro as reporter)

| Run | Setup | Result |
|---|---|---|
| 1 | released v0.5.4 AppImage, unmodified | `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` |
| 2 | same AppImage, only `libwayland-client.so.0` removed | no abort, app runs (EGL up via swrast) |

Container: Fedora 44, mesa-libEGL 26.0.8, libwayland-client 1.24.

## Fix

- `release.yml`: pre-seed `~/.cache/tauri/linuxdeploy-x86_64.AppImage` with pinned upstream [`1-alpha-20251107-1`](https://github.com/linuxdeploy/linuxdeploy/releases/tag/1-alpha-20251107-1) (compiled-in excludelist contains the `libwayland-client.so.0` entry — verified by extracting the binary). tauri-bundler skips its own download when the file exists (verified in tauri-cli 2.9.6 `prepare_tools`). Signing/updater pipeline untouched.
- `release.yml`: post-build assert — release job fails loudly if the AppImage ever bundles `libwayland-client` again (with extraction sanity check so it can't false-pass).
- `appimage-smoke.yml` (new): PRs touching `src-tauri/**` or the workflows build the AppImage and run the same assert + print the bundled lib inventory for diffing.
- `lib.rs`: comment corrected — the #107 env vars help on fragile-but-working EGL stacks, but cannot prevent this abort.

## Regression risk

Removing the bundled copy means hosts must provide wayland ≥ 1.22 symbols — every host with glibc 2.39 (already required by a noble-built AppImage) qualifies. Currently-working users already resolve identical symbols from their system copy. Remaining bundled `libwayland-egl/cursor/server` were analysed at symbol level and are not implicated (Mesa's import surface there is ≤ 1.6-era). The smoke workflow guards the bundle composition going forward.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)