### PR TITLE
fix: support pnpm 11

### DIFF
--- a/.github/workflows/appimage-smoke.yml
+++ b/.github/workflows/appimage-smoke.yml
@@ -35,9 +35,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/appimage-smoke.yml
+++ b/.github/workflows/appimage-smoke.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,9 +159,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-enable-pre-post-scripts=true
-auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",
+  "packageManager": "pnpm@11.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Vesperino/MerMarkEditor.git"
@@ -68,18 +69,6 @@
     "lowlight": "^3.3.0",
     "mermaid": "^11.15.0",
     "vue": "^3.5.13"
-  },
-  "pnpm": {
-    "overrides": {
-      "markdown-it": ">=14.1.1",
-      "rollup": ">=4.59.0",
-      "minimatch": ">=9.0.7",
-      "dompurify": ">=3.4.0",
-      "lodash-es": ">=4.18.0",
-      "js-cookie": ">=3.0.7",
-      "postcss": ">=8.5.10",
-      "uuid": ">=11.1.1"
-    }
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,16 @@
+overrides:
+  markdown-it: '>=14.1.1'
+  rollup: '>=4.59.0'
+  minimatch: '>=9.0.7'
+  dompurify: '>=3.4.0'
+  lodash-es: '>=4.18.0'
+  js-cookie: '>=3.0.7'
+  postcss: '>=8.5.10'
+  uuid: '>=11.1.1'
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+
+enablePrePostScripts: true
+autoInstallPeers: true


### PR DESCRIPTION
Fixes #111

## Problem

pnpm 11 introduces two breaking changes that prevent the project from installing:

1. The `pnpm` field in `package.json` is no longer read. Our security `overrides` lived there, so pnpm 11 printed a warning and ignored them.
2. Ignored build scripts are now a hard error (`ERR_PNPM_IGNORED_BUILDS`, exit 1) instead of a warning. `esbuild` and `sharp` need explicit approval, and the old `onlyBuiltDependencies` setting was removed in favor of the `allowBuilds` map.

## Changes

- New `pnpm-workspace.yaml` with the `overrides` (moved from `package.json`), `allowBuilds` approving `esbuild` and `sharp`, plus `enablePrePostScripts` and `autoInstallPeers` moved from `.npmrc` (pnpm 11 reads INI files only for registry/auth settings).
- Removed the `pnpm` field from `package.json` and added `packageManager: "pnpm@11.3.0"`.
- Deleted `.npmrc`.
- CI: bumped `pnpm/action-setup` v2 to v4 and dropped the hardcoded `version: 8`; the action now resolves the version from the `packageManager` field.

## Verification

On Windows with `npx pnpm@11.3.0`:

- Before the fix: `pnpm install` reproduces the exact error from the issue (exit 1).
- After the fix: `pnpm install` succeeds, `sharp` loads, `esbuild` postinstall runs (version 0.25.12 resolves).
- `pnpm run build` (vue-tsc + vite) succeeds.
- `pnpm run test`: 871 tests pass across 65 files.
- `pnpm-lock.yaml` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)