### PR TITLE
fix: Editor Font in Minimal theme, Code+Preview scroll sync, Tab in code view (#120, #121, #122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ---
 
+# Release v0.6.3 — Tab indentation and font fixes
+
+## Features
+
+- Indent with Tab in the code view: press Tab to insert a tab character, select multiple lines and press Tab / Shift+Tab to indent or outdent the whole block (#123)
+
+## Bug fixes
+
+- Fix the Editor Font setting having no effect in the Minimal theme; your chosen font now applies everywhere, and the "System Default" preset keeps Minimal's serif look (#123)
+- Fix Code + Preview panes slowly scrolling on their own after you stop scrolling on macOS trackpads (#123)
+- Fix Tab moving focus out of the editor instead of editing your document (#123)
+- Fix lists nested with tabs being flattened to a single level when switching between Code and Visual views (#123)
+
+## UI/UX
+
+- Tab in the visual editor now indents and outdents list items, inserts a tab inside code blocks, and never kicks the cursor out of your document (#123)
+
+---
+
 # Release v0.6.2 — Indented code blocks keep their indentation
 
 ## Bug fixes

--- a/docs/release-notes/v0.6.3/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.6.3/RELEASE_NOTES.md
@@ -1,0 +1,16 @@
+# Release v0.6.3 — Tab indentation and font fixes
+
+## Features
+
+- Indent with Tab in the code view: press Tab to insert a tab character, select multiple lines and press Tab / Shift+Tab to indent or outdent the whole block (#123)
+
+## Bug fixes
+
+- Fix the Editor Font setting having no effect in the Minimal theme; your chosen font now applies everywhere, and the "System Default" preset keeps Minimal's serif look (#123)
+- Fix Code + Preview panes slowly scrolling on their own after you stop scrolling on macOS trackpads (#123)
+- Fix Tab moving focus out of the editor instead of editing your document (#123)
+- Fix lists nested with tabs being flattened to a single level when switching between Code and Visual views (#123)
+
+## UI/UX
+
+- Tab in the visual editor now indents and outdents list items, inserts a tab inside code blocks, and never kicks the cursor out of your document (#123)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.6.2"
+version = "0.6.3"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/__tests__/composables/useScrollSync.test.ts
+++ b/src/__tests__/composables/useScrollSync.test.ts
@@ -60,8 +60,91 @@ describe('scrollTopFromRatio', () => {
   });
 });
 
-describe('useScrollSync attach/detach', () => {
-  it('adds scroll listeners on attach and removes them on detach', () => {
+describe('useScrollSync', () => {
+  const defineScrollMetrics = (
+    element: HTMLElement,
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+  ) => {
+    Object.defineProperties(element, {
+      scrollTop: { value: scrollTop, writable: true },
+      scrollHeight: { value: scrollHeight },
+      clientHeight: { value: clientHeight },
+    });
+  };
+
+  it('syncs the other pane when the owner scrolls', () => {
+    const code = document.createElement('div');
+    const preview = document.createElement('div');
+    defineScrollMetrics(code, 400, 1000, 200);
+    defineScrollMetrics(preview, 0, 2000, 200);
+
+    const sync = useScrollSync();
+    sync.attach(code, preview);
+    code.dispatchEvent(new Event('wheel'));
+    code.dispatchEvent(new Event('scroll'));
+
+    expect(preview.scrollTop).toBe(900);
+  });
+
+  it('does not write back when the non-owner pane emits a scroll event', () => {
+    const code = document.createElement('div');
+    const preview = document.createElement('div');
+    defineScrollMetrics(code, 400, 1000, 200);
+    defineScrollMetrics(preview, 0, 2000, 200);
+
+    const sync = useScrollSync();
+    sync.attach(code, preview);
+    code.dispatchEvent(new Event('wheel'));
+    code.dispatchEvent(new Event('scroll'));
+    code.scrollTop = 401;
+    preview.dispatchEvent(new Event('scroll'));
+
+    expect(code.scrollTop).toBe(401);
+  });
+
+  it('switches ownership when the user wheels the other pane', () => {
+    const code = document.createElement('div');
+    const preview = document.createElement('div');
+    defineScrollMetrics(code, 400, 1000, 200);
+    defineScrollMetrics(preview, 0, 2000, 200);
+
+    const sync = useScrollSync();
+    sync.attach(code, preview);
+    code.dispatchEvent(new Event('wheel'));
+    code.dispatchEvent(new Event('scroll'));
+    preview.scrollTop = 450;
+    preview.dispatchEvent(new Event('wheel'));
+    preview.dispatchEvent(new Event('scroll'));
+
+    expect(code.scrollTop).toBe(200);
+  });
+
+  it('skips destination writes within the 1px deadband', () => {
+    const code = document.createElement('div');
+    const preview = document.createElement('div');
+    defineScrollMetrics(code, 400, 1000, 200);
+    let previewTop = 900.5;
+    const previewSetter = vi.fn((value: number) => { previewTop = value; });
+    Object.defineProperties(preview, {
+      scrollTop: {
+        get: () => previewTop,
+        set: previewSetter,
+      },
+      scrollHeight: { value: 2000 },
+      clientHeight: { value: 200 },
+    });
+
+    const sync = useScrollSync();
+    sync.attach(code, preview);
+    code.dispatchEvent(new Event('scroll'));
+
+    expect(previewSetter).not.toHaveBeenCalled();
+    expect(preview.scrollTop).toBe(900.5);
+  });
+
+  it('adds and removes listeners for every handled event type', () => {
     const code = document.createElement('div');
     const preview = document.createElement('div');
     const codeAdd = vi.spyOn(code, 'addEventListener');
@@ -71,11 +154,15 @@ describe('useScrollSync attach/detach', () => {
 
     const sync = useScrollSync();
     sync.attach(code, preview);
-    expect(codeAdd).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
-    expect(previewAdd).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true });
+    for (const eventType of ['scroll', 'wheel', 'touchstart', 'pointerdown']) {
+      expect(codeAdd).toHaveBeenCalledWith(eventType, expect.any(Function), { passive: true });
+      expect(previewAdd).toHaveBeenCalledWith(eventType, expect.any(Function), { passive: true });
+    }
 
     sync.detach();
-    expect(codeRemove).toHaveBeenCalledWith('scroll', expect.any(Function));
-    expect(previewRemove).toHaveBeenCalledWith('scroll', expect.any(Function));
+    for (const eventType of ['scroll', 'wheel', 'touchstart', 'pointerdown']) {
+      expect(codeRemove).toHaveBeenCalledWith(eventType, expect.any(Function));
+      expect(previewRemove).toHaveBeenCalledWith(eventType, expect.any(Function));
+    }
   });
 });

--- a/src/__tests__/composables/useSettings.test.ts
+++ b/src/__tests__/composables/useSettings.test.ts
@@ -109,17 +109,28 @@ describe('useSettings', () => {
       expect(settings.value.mermaidFenceClose).toBe('```');
     });
 
-    it('should set editor font family', () => {
+    it('should set the resolved editor font family CSS variable for a non-system font', () => {
       const { settings, setEditorFontFamily } = useSettings();
       setEditorFontFamily('georgia');
       expect(settings.value.editorFontFamily).toBe('georgia');
+      expect(document.documentElement.style.getPropertyValue('--editor-font-family'))
+        .toBe('Georgia, "Times New Roman", Times, serif');
       setEditorFontFamily('system');
     });
 
-    it('should set code font family', () => {
+    it('should remove the editor font family CSS variable for the system font', () => {
+      const { setEditorFontFamily } = useSettings();
+      setEditorFontFamily('georgia');
+      setEditorFontFamily('system');
+      expect(document.documentElement.style.getPropertyValue('--editor-font-family')).toBe('');
+    });
+
+    it('should keep setting the resolved code font family CSS variable', () => {
       const { settings, setCodeFontFamily } = useSettings();
       setCodeFontFamily('consolas');
       expect(settings.value.codeFontFamily).toBe('consolas');
+      expect(document.documentElement.style.getPropertyValue('--code-font-family'))
+        .toBe('"Consolas", "Courier New", monospace');
       setCodeFontFamily('fira-code');
     });
 

--- a/src/__tests__/composables/useTextareaTabIndent.test.ts
+++ b/src/__tests__/composables/useTextareaTabIndent.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ref } from 'vue';
+import { useTextareaTabIndent } from '../../composables/useTextareaTabIndent';
+
+function setup(text: string, selectionStart: number, selectionEnd: number) {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setSelectionRange(selectionStart, selectionEnd);
+  const textareaRef = ref<HTMLTextAreaElement | null>(textarea);
+  const onChange = vi.fn((value: string) => {
+    textarea.value = value;
+  });
+  const { handleKeydown } = useTextareaTabIndent({ textareaRef, onChange });
+
+  return { textarea, onChange, handleKeydown };
+}
+
+describe('useTextareaTabIndent', () => {
+  it('handles Tab and restores the resulting caret', async () => {
+    const { textarea, onChange, handleKeydown } = setup('abc', 1, 1);
+    const event = new KeyboardEvent('keydown', { key: 'Tab', cancelable: true });
+
+    handleKeydown(event);
+    await Promise.resolve();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenCalledWith('a\tbc');
+    expect(textarea.selectionStart).toBe(2);
+    expect(textarea.selectionEnd).toBe(2);
+  });
+
+  it('handles Shift+Tab when indentation can be removed', async () => {
+    const { textarea, onChange, handleKeydown } = setup('    abc', 7, 7);
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    handleKeydown(event);
+    await Promise.resolve();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenCalledWith('abc');
+    expect(textarea.selectionStart).toBe(3);
+    expect(textarea.selectionEnd).toBe(3);
+  });
+
+  it('leaves modified Tab combinations untouched', () => {
+    for (const modifier of ['ctrlKey', 'altKey', 'metaKey'] as const) {
+      const { onChange, handleKeydown } = setup('abc', 1, 1);
+      const event = new KeyboardEvent('keydown', {
+        key: 'Tab',
+        [modifier]: true,
+        cancelable: true,
+      });
+
+      handleKeydown(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(onChange).not.toHaveBeenCalled();
+    }
+  });
+
+  it('prevents Shift+Tab without changing text when there is nothing to outdent', () => {
+    const { onChange, handleKeydown } = setup('abc', 1, 1);
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    handleKeydown(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -616,6 +616,35 @@ describe('round-trip conversion', () => {
 });
 
 describe('nested list round-trip', () => {
+  it('nests an unordered list indented by a tab', () => {
+    const html = markdownToHtml('- a\n\t- b');
+    expect(html).toContain('<li><p>a</p><ul><li><p>b</p></li></ul></li>');
+  });
+
+  it('preserves two levels of tab indentation', () => {
+    const html = markdownToHtml('- a\n\t\t- b');
+    expect((html.match(/<ul>/g) || []).length).toBe(3);
+    expect(htmlToMarkdown(html)).toBe('- a\n    - b');
+  });
+
+  it('treats two spaces and one tab as the same indentation level', () => {
+    const html = markdownToHtml('- a\n  - b\n\t- c');
+    expect(html).toContain('<ul><li><p>b</p></li><li><p>c</p></li></ul>');
+  });
+
+  it('nests ordered and task lists indented by a tab', () => {
+    const orderedHtml = markdownToHtml('1. a\n\t1. b');
+    const taskHtml = markdownToHtml('- [ ] a\n\t- [x] b');
+
+    expect(orderedHtml).toContain('<li><p>a</p><ol><li><p>b</p></li></ol></li>');
+    expect((taskHtml.match(/data-type="taskList"/g) || []).length).toBe(2);
+    expect(taskHtml).toContain('<p>a</p><ul data-type="taskList">');
+  });
+
+  it('keeps space-indented list behavior unchanged', () => {
+    expect(markdownToHtml('- a\n  - b')).toBe(markdownToHtml('- a\n\t- b'));
+  });
+
   it('preserves simple nested unordered list', () => {
     const original = '- Parent\n  - Child 1\n  - Child 2';
     const html = markdownToHtml(original);

--- a/src/__tests__/utils/textTabIndent.test.ts
+++ b/src/__tests__/utils/textTabIndent.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { applyTabIndent } from '../../utils/textTabIndent';
+
+const apply = (
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  direction: 'indent' | 'outdent',
+) => applyTabIndent({ text, selectionStart, selectionEnd, direction });
+
+describe('applyTabIndent — indent', () => {
+  it('inserts a tab at the caret', () => {
+    expect(apply('abc', 1, 1, 'indent')).toEqual({
+      text: 'a\tbc',
+      selectionStart: 2,
+      selectionEnd: 2,
+    });
+  });
+
+  it('replaces a single-line selection with a tab', () => {
+    expect(apply('abcdef', 1, 4, 'indent')).toEqual({
+      text: 'a\tef',
+      selectionStart: 2,
+      selectionEnd: 2,
+    });
+  });
+
+  it('indents every selected line and adjusts the selection', () => {
+    expect(apply('one\ntwo\nthree', 1, 10, 'indent')).toEqual({
+      text: '\tone\n\ttwo\n\tthree',
+      selectionStart: 2,
+      selectionEnd: 13,
+    });
+  });
+
+  it('excludes a line when the selection ends at its start', () => {
+    expect(apply('one\ntwo\nthree', 1, 8, 'indent')).toEqual({
+      text: '\tone\n\ttwo\nthree',
+      selectionStart: 2,
+      selectionEnd: 10,
+    });
+  });
+});
+
+describe('applyTabIndent — outdent', () => {
+  it('removes one leading tab from every selected line', () => {
+    expect(apply('\tone\n\t\ttwo\nthree', 0, 16, 'outdent')).toEqual({
+      text: 'one\n\ttwo\nthree',
+      selectionStart: 0,
+      selectionEnd: 14,
+    });
+  });
+
+  it('removes up to four leading spaces from every selected line', () => {
+    expect(apply('    one\n  two', 2, 13, 'outdent')).toEqual({
+      text: 'one\ntwo',
+      selectionStart: 0,
+      selectionEnd: 7,
+    });
+  });
+
+  it('keeps a caret from crossing its line start', () => {
+    expect(apply('first\n    second', 8, 8, 'outdent')).toEqual({
+      text: 'first\nsecond',
+      selectionStart: 6,
+      selectionEnd: 6,
+    });
+  });
+
+  it('returns null when no touched line can be outdented', () => {
+    expect(apply('one\ntwo', 0, 7, 'outdent')).toBeNull();
+  });
+});

--- a/src/components/CodeEditor.vue
+++ b/src/components/CodeEditor.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { useEditorZoom } from '../composables/useEditorZoom';
 import { useSettings } from '../composables/useSettings';
 import { useTextareaLineMove } from '../composables/useTextareaLineMove';
+import { useTextareaTabIndent } from '../composables/useTextareaTabIndent';
 
 const { zoomScale } = useEditorZoom();
 const { settings } = useSettings();
@@ -136,6 +137,16 @@ const { handleKeydown: handleLineMoveKeydown } = useTextareaLineMove({
   onChange: (value) => emit('update:modelValue', value),
 });
 
+const { handleKeydown: handleTabIndentKeydown } = useTextareaTabIndent({
+  textareaRef,
+  onChange: (value) => emit('update:modelValue', value),
+});
+
+const handleKeydown = (event: KeyboardEvent) => {
+  handleLineMoveKeydown(event);
+  handleTabIndentKeydown(event);
+};
+
 const handleScroll = (event: Event) => {
   const target = event.target as HTMLTextAreaElement;
   if (gutterRef.value) {
@@ -173,7 +184,7 @@ const handleScroll = (event: Event) => {
       :style="codeZoomStyle"
       :value="modelValue"
       @input="handleInput"
-      @keydown="handleLineMoveKeydown"
+      @keydown="handleKeydown"
       @scroll="handleScroll"
       spellcheck="false"
       autocomplete="off"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -264,16 +264,24 @@ const ListKeymap = Extension.create({
   addKeyboardShortcuts() {
     return {
       Tab: ({ editor }) => {
-        if (editor.isActive("listItem") || editor.isActive("taskItem")) {
-          return editor.commands.sinkListItem("listItem") || editor.commands.sinkListItem("taskItem");
+        if (editor.isActive("codeBlock")) {
+          editor.commands.insertContent("\t");
+          return true;
         }
-        return false;
+        if (editor.isActive("listItem") || editor.isActive("taskItem")) {
+          if (!editor.commands.sinkListItem("listItem")) {
+            editor.commands.sinkListItem("taskItem");
+          }
+        }
+        return true;
       },
       "Shift-Tab": ({ editor }) => {
         if (editor.isActive("listItem") || editor.isActive("taskItem")) {
-          return editor.commands.liftListItem("listItem") || editor.commands.liftListItem("taskItem");
+          if (!editor.commands.liftListItem("listItem")) {
+            editor.commands.liftListItem("taskItem");
+          }
         }
-        return false;
+        return true;
       },
     };
   },

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -727,7 +727,7 @@ onUnmounted(() => {
             </div>
 
             <!-- Font preview -->
-            <div class="font-preview" :style="{ fontFamily: `var(--editor-font-family)`, lineHeight: settings.editorLineHeight }">
+            <div class="font-preview" :style="{ fontFamily: `var(--editor-font-family, inherit)`, lineHeight: settings.editorLineHeight }">
               The quick brown fox jumps over the lazy dog. 0123456789
             </div>
           </div>

--- a/src/composables/useScrollSync.ts
+++ b/src/composables/useScrollSync.ts
@@ -38,33 +38,48 @@ export interface ScrollSync {
 
 /**
  * Bidirectional proportional scroll-sync between two scroll containers.
- * A shared lock plus a requestAnimationFrame release prevents the programmatic
- * scroll of one side from bouncing back through the other side's scroll event.
+ * Ownership prevents asynchronously delivered programmatic scroll events from
+ * bouncing back after the originating handler has completed.
  */
 export function useScrollSync(): ScrollSync {
   let code: HTMLElement | null = null;
   let preview: HTMLElement | null = null;
-  let lock = false;
+  let owner: 'code' | 'preview' | null = null;
 
   const sync = (src: HTMLElement, dst: HTMLElement) => {
-    if (lock) return;
-    lock = true;
-    dst.scrollTop = proportionalTarget(
+    const target = proportionalTarget(
       src.scrollTop, src.scrollHeight, src.clientHeight,
       dst.scrollHeight, dst.clientHeight,
     );
-    requestAnimationFrame(() => { lock = false; });
+    if (Math.abs(target - dst.scrollTop) < 1) return;
+    dst.scrollTop = target;
   };
 
-  const onCodeScroll = () => { if (code && preview) sync(code, preview); };
-  const onPreviewScroll = () => { if (code && preview) sync(preview, code); };
+  const onCodeIntent = () => { owner = 'code'; };
+  const onPreviewIntent = () => { owner = 'preview'; };
+  const onCodeScroll = () => {
+    if (!code || !preview) return;
+    if (owner === null) owner = 'code';
+    if (owner === 'code') sync(code, preview);
+  };
+  const onPreviewScroll = () => {
+    if (!code || !preview) return;
+    if (owner === null) owner = 'preview';
+    if (owner === 'preview') sync(preview, code);
+  };
 
   const detach = () => {
     code?.removeEventListener('scroll', onCodeScroll);
+    code?.removeEventListener('wheel', onCodeIntent);
+    code?.removeEventListener('touchstart', onCodeIntent);
+    code?.removeEventListener('pointerdown', onCodeIntent);
     preview?.removeEventListener('scroll', onPreviewScroll);
+    preview?.removeEventListener('wheel', onPreviewIntent);
+    preview?.removeEventListener('touchstart', onPreviewIntent);
+    preview?.removeEventListener('pointerdown', onPreviewIntent);
     code = null;
     preview = null;
-    lock = false;
+    owner = null;
   };
 
   const attach = (codeEl: HTMLElement, previewEl: HTMLElement) => {
@@ -72,7 +87,13 @@ export function useScrollSync(): ScrollSync {
     code = codeEl;
     preview = previewEl;
     code.addEventListener('scroll', onCodeScroll, { passive: true });
+    code.addEventListener('wheel', onCodeIntent, { passive: true });
+    code.addEventListener('touchstart', onCodeIntent, { passive: true });
+    code.addEventListener('pointerdown', onCodeIntent, { passive: true });
     preview.addEventListener('scroll', onPreviewScroll, { passive: true });
+    preview.addEventListener('wheel', onPreviewIntent, { passive: true });
+    preview.addEventListener('touchstart', onPreviewIntent, { passive: true });
+    preview.addEventListener('pointerdown', onPreviewIntent, { passive: true });
   };
 
   return { attach, detach };

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -786,7 +786,11 @@ function applyCodeThemeVars(root: CSSStyleDeclaration, theme: CodeThemeMode) {
 // Apply all CSS custom properties to document root
 function applyCssVars(s: AppSettings) {
   const root = document.documentElement.style;
-  root.setProperty('--editor-font-family', resolveEditorFont(s.editorFontFamily));
+  if (s.editorFontFamily === 'system') {
+    root.removeProperty('--editor-font-family');
+  } else {
+    root.setProperty('--editor-font-family', resolveEditorFont(s.editorFontFamily));
+  }
   root.setProperty('--code-font-family', resolveCodeFont(s.codeFontFamily));
   root.setProperty('--editor-line-height', `${s.editorLineHeight}`);
   // Editor surface paddings — picked up by the Minimal theme via

--- a/src/composables/useTextareaTabIndent.ts
+++ b/src/composables/useTextareaTabIndent.ts
@@ -1,0 +1,39 @@
+import type { Ref } from 'vue';
+import { applyTabIndent, type TabIndentDirection } from '../utils/textTabIndent';
+
+export interface UseTextareaTabIndentOptions {
+  textareaRef: Ref<HTMLTextAreaElement | null>;
+  onChange: (value: string) => void;
+}
+
+function directionFromKey(event: KeyboardEvent): TabIndentDirection | null {
+  if (event.key !== 'Tab' || event.ctrlKey || event.altKey || event.metaKey) return null;
+  return event.shiftKey ? 'outdent' : 'indent';
+}
+
+export function useTextareaTabIndent({ textareaRef, onChange }: UseTextareaTabIndentOptions) {
+  const handleKeydown = (event: KeyboardEvent) => {
+    const direction = directionFromKey(event);
+    if (!direction) return;
+    const textarea = textareaRef.value;
+    if (!textarea) return;
+    event.preventDefault();
+
+    const result = applyTabIndent({
+      text: textarea.value,
+      selectionStart: textarea.selectionStart,
+      selectionEnd: textarea.selectionEnd,
+      direction,
+    });
+    if (!result) return;
+
+    onChange(result.text);
+    queueMicrotask(() => {
+      const el = textareaRef.value;
+      if (!el) return;
+      el.setSelectionRange(result.selectionStart, result.selectionEnd);
+    });
+  };
+
+  return { handleKeydown };
+}

--- a/src/styles/themes/minimal.css
+++ b/src/styles/themes/minimal.css
@@ -106,8 +106,8 @@ html[data-variant="minimal"] {
   --minimal-font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, "Helvetica Neue", Arial, sans-serif;
 
-  /* Editor inherits serif by default; user font setting still wins via
-     --editor-font-family override in useSettings. */
+  /* Minimal uses its serif stack when the system preset leaves
+     --editor-font-family unset; other presets define the override. */
   --editor-line-height: 1.7;
   --toolbar-height: 38px;
 }
@@ -432,7 +432,7 @@ html[data-variant="minimal"] .editor-container {
 html[data-variant="minimal"] .editor-content,
 html[data-variant="minimal"] .ProseMirror,
 html[data-variant="minimal"] .tiptap {
-  font-family: var(--minimal-font-serif);
+  font-family: var(--editor-font-family, var(--minimal-font-serif));
   font-size: 17px;
   line-height: 1.75;
   color: var(--text-primary);
@@ -455,7 +455,7 @@ html[data-variant="minimal"] .ProseMirror h6,
 html[data-variant="minimal"] .tiptap h1,
 html[data-variant="minimal"] .tiptap h2,
 html[data-variant="minimal"] .tiptap h3 {
-  font-family: var(--minimal-font-serif);
+  font-family: var(--editor-font-family, var(--minimal-font-serif));
   font-weight: 600;
   letter-spacing: -0.01em;
   border-bottom: none;

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -14,6 +14,15 @@ interface ListItem {
   extraContent: string[];
 }
 
+function getIndentWidth(whitespace: string): number {
+  return Array.from(whitespace).reduce((width, character) => width + (character === '\t' ? 2 : 1), 0);
+}
+
+function hasListContinuationIndent(line: string): boolean {
+  const leadingWhitespace = line.match(/^\s*/)?.[0] ?? '';
+  return getIndentWidth(leadingWhitespace) >= 2;
+}
+
 function parseMarkdownListBlock(lines: string[], startIndex: number): { html: string; endIndex: number } {
   const items: ListItem[] = [];
   let idx = startIndex;
@@ -27,7 +36,7 @@ function parseMarkdownListBlock(lines: string[], startIndex: number): { html: st
     const olMatch = line.match(/^(\s*)(\d+)\. (.*)$/);
 
     if (taskMatch) {
-      const indent = Math.floor(taskMatch[1].length / 2);
+      const indent = Math.floor(getIndentWidth(taskMatch[1]) / 2);
       const content = taskMatch[3].trim();
       if (content) {
         items.push({
@@ -40,14 +49,14 @@ function parseMarkdownListBlock(lines: string[], startIndex: number): { html: st
       }
       idx++;
     } else if (ulMatch) {
-      const indent = Math.floor(ulMatch[1].length / 2);
+      const indent = Math.floor(getIndentWidth(ulMatch[1]) / 2);
       const content = ulMatch[2].trim();
       if (content) {
         items.push({ indent, content, type: 'ul', extraContent: [] });
       }
       idx++;
     } else if (olMatch) {
-      const indent = Math.floor(olMatch[1].length / 2);
+      const indent = Math.floor(getIndentWidth(olMatch[1]) / 2);
       const content = olMatch[3].trim();
       if (content) {
         items.push({ indent, content, type: 'ol', number: parseInt(olMatch[2]), extraContent: [] });
@@ -62,12 +71,12 @@ function parseMarkdownListBlock(lines: string[], startIndex: number): { html: st
           lookAhead++;
         }
         if (lookAhead < lines.length &&
-            (/^\s*- /.test(lines[lookAhead]) || /^\s*\d+\. /.test(lines[lookAhead]) || /^\s{2,}/.test(lines[lookAhead]))) {
+            (/^\s*- /.test(lines[lookAhead]) || /^\s*\d+\. /.test(lines[lookAhead]) || hasListContinuationIndent(lines[lookAhead]))) {
           idx++;
           continue;
         }
         break;
-      } else if (/^\s{2,}/.test(line)) {
+      } else if (hasListContinuationIndent(line)) {
         // Indented continuation line - belongs to the previous list item
         const lastItem = items[items.length - 1];
         lastItem.extraContent.push(trimmed);
@@ -83,6 +92,18 @@ function parseMarkdownListBlock(lines: string[], startIndex: number): { html: st
   if (items.length === 0) {
     return { html: '', endIndex: idx };
   }
+
+  const wrapMissingListLevels = (html: string, type: ListItem['type'], count: number): string => {
+    let wrapped = html;
+    for (let level = 0; level < count; level++) {
+      if (type === 'task') {
+        wrapped = `<ul data-type="taskList"><li data-type="taskItem" data-checked="false">${wrapped}</li></ul>`;
+      } else {
+        wrapped = `<${type}><li>${wrapped}</li></${type}>`;
+      }
+    }
+    return wrapped;
+  };
 
   const buildNestedList = (items: ListItem[], startIdx: number, baseIndent: number): { html: string; endIdx: number } => {
     if (startIdx >= items.length) {
@@ -126,8 +147,9 @@ function parseMarkdownListBlock(lines: string[], startIndex: number): { html: st
         i++;
 
         if (i < items.length && items[i].indent > baseIndent) {
-          const nested = buildNestedList(items, i, items[i].indent);
-          html += nested.html;
+          const nestedIndent = items[i].indent;
+          const nested = buildNestedList(items, i, nestedIndent);
+          html += wrapMissingListLevels(nested.html, items[i].type, nestedIndent - baseIndent - 1);
           i = nested.endIdx;
         }
 
@@ -348,7 +370,7 @@ function isInsideListContext(lines: string[], startIdx: number): boolean {
     if (line.trim() === '') continue;
     if (isListItemLine(line)) return true;
     // Continuation-shaped line — the list (if any) starts further up.
-    if (/^\s{2,}/.test(line)) continue;
+    if (hasListContinuationIndent(line)) continue;
     return false;
   }
   return false;

--- a/src/utils/textTabIndent.ts
+++ b/src/utils/textTabIndent.ts
@@ -1,0 +1,102 @@
+export type TabIndentDirection = 'indent' | 'outdent';
+
+export interface TabIndentInput {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+  direction: TabIndentDirection;
+}
+
+export interface TabIndentResult {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+interface Removal {
+  start: number;
+  length: number;
+}
+
+function lineStartAt(text: string, position: number): number {
+  return text.lastIndexOf('\n', position - 1) + 1;
+}
+
+function touchedLineStarts(text: string, selectionStart: number, selectionEnd: number): number[] {
+  const first = lineStartAt(text, selectionStart);
+  const lastPosition = selectionEnd > selectionStart ? selectionEnd - 1 : selectionEnd;
+  const last = lineStartAt(text, lastPosition);
+  const starts = [first];
+
+  let current = first;
+  while (current < last) {
+    const newline = text.indexOf('\n', current);
+    if (newline === -1) break;
+    current = newline + 1;
+    starts.push(current);
+  }
+
+  return starts;
+}
+
+function leadingIndentLength(text: string, lineStart: number): number {
+  if (text[lineStart] === '\t') return 1;
+
+  let spaces = 0;
+  while (spaces < 4 && text[lineStart + spaces] === ' ') spaces += 1;
+  return spaces;
+}
+
+function positionAfterRemovals(position: number, removals: Removal[]): number {
+  let removed = 0;
+  for (const removal of removals) {
+    if (position <= removal.start) break;
+    removed += Math.min(removal.length, position - removal.start);
+  }
+  return position - removed;
+}
+
+export function applyTabIndent(input: TabIndentInput): TabIndentResult | null {
+  const { text, selectionStart, selectionEnd, direction } = input;
+
+  if (direction === 'indent' && lineStartAt(text, selectionStart) === lineStartAt(text, selectionEnd)) {
+    return {
+      text: `${text.slice(0, selectionStart)}\t${text.slice(selectionEnd)}`,
+      selectionStart: selectionStart + 1,
+      selectionEnd: selectionStart + 1,
+    };
+  }
+
+  const lineStarts = touchedLineStarts(text, selectionStart, selectionEnd);
+
+  if (direction === 'indent') {
+    let nextText = text;
+    for (let i = lineStarts.length - 1; i >= 0; i--) {
+      const start = lineStarts[i];
+      nextText = `${nextText.slice(0, start)}\t${nextText.slice(start)}`;
+    }
+
+    return {
+      text: nextText,
+      selectionStart: selectionStart + lineStarts.filter((start) => start <= selectionStart).length,
+      selectionEnd: selectionEnd + lineStarts.filter((start) => start <= selectionEnd).length,
+    };
+  }
+
+  const removals = lineStarts
+    .map((start) => ({ start, length: leadingIndentLength(text, start) }))
+    .filter((removal) => removal.length > 0);
+  if (removals.length === 0) return null;
+
+  let nextText = text;
+  for (let i = removals.length - 1; i >= 0; i--) {
+    const { start, length } = removals[i];
+    nextText = `${nextText.slice(0, start)}${nextText.slice(start + length)}`;
+  }
+
+  return {
+    text: nextText,
+    selectionStart: positionAfterRemovals(selectionStart, removals),
+    selectionEnd: positionAfterRemovals(selectionEnd, removals),
+  };
+}


### PR DESCRIPTION
## Summary

Bundles the fixes for #120, #121 and #122, plus a follow-up hardening of Tab handling in the visual editor discovered during review.

### #120: Editor Font setting has no effect (Minimal theme)
The Minimal theme applied `var(--minimal-font-serif)` directly to the editor content with higher specificity than the rule consuming `--editor-font-family`, so the Settings > Editor > Editor Font choice never applied in that variant (regression since v0.2.7). Minimal now falls back to its serif stack only when the 'system' preset is active; any explicit font wins in every theme variant.

### #121: Code + Preview keeps scrolling on its own (macOS)
The bidirectional scroll sync used a lock released on the next animation frame, but WKWebView delivers the scroll event of a programmatic scrollTop write after that release, so echoes synced back and rounding drift kept both panes slowly scrolling. The sync now follows explicit ownership (wheel/touchstart/pointerdown mark the pane the user drives, only the owner propagates) plus a 1px deadband. Needs confirmation on real macOS hardware.

### #122: Tab moves focus instead of indenting in the code view
The code view textarea had no Tab handling. Tab now inserts a tab at the caret or indents all selected lines, Shift+Tab outdents one leading tab or up to four leading spaces per line, and focus always stays in the textarea. Ctrl/Alt/Meta combinations are untouched.

### Follow-up: Tab in the visual editor and tab-indented lists
Two related gaps found while reviewing #122:
- In the visual editor, Tab escaped to browser focus traversal whenever list sink/lift was impossible (first list item, paragraphs, headings). Tab and Shift+Tab are now always consumed: lists sink/lift when possible, code blocks insert a literal tab, everything else is a no-op.
- The markdown parser counted a leading tab as one character when measuring list indentation, flattening tab-indented nesting on every Code -> Visual roundtrip. A tab now counts as one nesting level (two spaces), consistent with the serializer, for bullet, ordered and task lists including continuation lines and skipped levels.

## Test plan
- [x] `pnpm test:run`: 1011 tests green on the merged branch (21 new)
- [x] `vue-tsc --noEmit` clean
- [x] #120 verified end to end via the real Settings UI (Playwright): Minimal + Georgia applies, Minimal + system keeps serif, Default variant unchanged
- [x] #121 smoke tested in Chromium: proportional sync both directions, ownership handoff, no drift, programmatic echo suppressed
- [x] #122 verified with real key presses: caret insert, multiline indent/outdent, focus retention on empty outdent
- [x] Visual editor verified with real key presses: focus stays on Tab in paragraph, first list item, and code block (inserts \t); sink/lift symmetric; tab-nested ul/ol/task lists survive Code -> Visual -> Code
- [ ] #121 confirmed on macOS by the reporter

🤖 Generated with [Claude Code](https://claude.com/claude-code)