### PR TITLE
fix: in-document anchor links silently do nothing (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ---
 
+# Release v0.6.5 — Links inside your document jump where they should
+
+## Bug fixes
+
+- Fix clicking a `[Section](#section)` link doing nothing at all; it now scrolls to the heading (#132)
+- Fix headings containing dashes, ampersands, accented letters or non-Latin script getting anchors no link could reach, so Polish and Chinese headings now work like any other (#132)
+- Fix links to a repeated heading always landing on the first one; every repeat now gets its own anchor (#132)
+- Fix anchor links searching the wrong side in split view instead of the pane you are looking at (#132)
+- Fix a document containing an unusual numeric character code failing to open (#132)
+
+## UI/UX
+
+- Heading anchors now match the ones GitHub produces, so a link copied out of a document rendered on GitHub resolves here too. Links written against MerMark's older anchors still work where the two differ only in dashes; the few that leaned on how ampersands or accented letters used to be handled need updating (#132)
+- Show a notice when a link points at a heading the document does not contain, instead of leaving the click looking like nothing happened (#132)
+
+---
+
 # Release v0.6.4 — Drag folders in, reveal files properly, native Wayland
 
 ## Features

--- a/docs/release-notes/v0.6.5/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.6.5/RELEASE_NOTES.md
@@ -1,0 +1,14 @@
+# Release v0.6.5 — Links inside your document jump where they should
+
+## Bug fixes
+
+- Fix clicking a `[Section](#section)` link doing nothing at all; it now scrolls to the heading (#132)
+- Fix headings containing dashes, ampersands, accented letters or non-Latin script getting anchors no link could reach, so Polish and Chinese headings now work like any other (#132)
+- Fix links to a repeated heading always landing on the first one; every repeat now gets its own anchor (#132)
+- Fix anchor links searching the wrong side in split view instead of the pane you are looking at (#132)
+- Fix a document containing an unusual numeric character code failing to open (#132)
+
+## UI/UX
+
+- Heading anchors now match the ones GitHub produces, so a link copied out of a document rendered on GitHub resolves here too. Links written against MerMark's older anchors still work where the two differ only in dashes; the few that leaned on how ampersands or accented letters used to be handled need updating (#132)
+- Show a notice when a link points at a heading the document does not contain, instead of leaving the click looking like nothing happened (#132)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@tiptap/vue-3": "^3.15.3",
     "diff": "^8.0.3",
     "docx": "^9.6.1",
+    "github-slugger": "^2.0.0",
     "lowlight": "^3.3.0",
     "mermaid": "^11.15.0",
     "vue": "^3.5.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       docx:
         specifier: ^9.6.1
         version: 9.6.1
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1337,6 +1340,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -1742,6 +1746,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -3865,6 +3872,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  github-slugger@2.0.0: {}
 
   glob@10.5.0:
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.6.4"
+version = "0.6.5"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.vue
+++ b/src/App.vue
@@ -241,7 +241,7 @@ const findTabByFilePath = (filePath: string) => {
 
 // ============ File Watcher & Reload ============
 const {
-  showToast, toastMessage, toastType, dismissToast,
+  showToast, toastMessage, toastType, dismissToast, showToastNotification,
   showConflictModal, conflictFileName, conflictFilePath, conflictDiffLines, conflictDiffStats,
   handleConflictKeepLocal, handleConflictLoadExternal, handleConflictMerge,
   manualReload,
@@ -496,6 +496,9 @@ const {
     // the file watcher is registered so external edits (e.g., AI) are
     // detected and trigger an editor reload.
     watchFile(filePath, content);
+  },
+  onAnchorNotFound: (anchor: string) => {
+    showToastNotification(t.value.anchorNotFound(anchor), 'warning');
   },
   onPreSaveConflict: (filePath: string, diskContent: string, localMarkdown: string) => {
     const tab = findTabByFilePath(filePath);

--- a/src/__tests__/composables/useCodeView.test.ts
+++ b/src/__tests__/composables/useCodeView.test.ts
@@ -45,7 +45,6 @@ vi.mock('../../utils/markdown-converter', () => ({
     }
     return `<p>HTML from: ${md}</p>`;
   },
-  generateSlug: (text: string) => text.toLowerCase().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-'),
 }));
 
 describe('useCodeView', () => {

--- a/src/__tests__/composables/useFileOperations.test.ts
+++ b/src/__tests__/composables/useFileOperations.test.ts
@@ -39,7 +39,11 @@ vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => mockGetCurrentWindow(),
 }));
 
-vi.mock('../../utils/markdown-converter', () => ({
+// Spread the real module so `generateSlug` stays the genuine implementation —
+// the anchor fallback compares against it, and a hand-copied stub would keep
+// passing after the real slug rules change.
+vi.mock('../../utils/markdown-converter', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/markdown-converter')>()),
   htmlToMarkdown: vi.fn((html: string) => `md:${html}`),
   markdownToHtml: vi.fn((md: string) => `<p>${md}</p>`),
   detectLineEnding: vi.fn(() => '\n'),
@@ -49,7 +53,10 @@ vi.mock('../../utils/markdown-converter', () => ({
 vi.mock('../../constants', () => ({
   EMPTY_TAB_CONTENT: '<p></p>',
   DEFAULT_FILE_NAME: 'dokument.md',
-  DOM_SELECTORS: { EDITOR_CONTAINER: '.editor-container' },
+  DOM_SELECTORS: {
+    EDITOR_CONTAINER: '.editor-container',
+    ACTIVE_EDITOR_CONTAINER: '.editor-pane.active .editor-container',
+  },
   TIMING: { MAXIMIZE_ANIMATION_DELAY: 0 },
 }));
 
@@ -433,5 +440,127 @@ describe('useFileOperations', () => {
       expect(mockReadTextFile).toHaveBeenCalledWith('/other/file.md');
       expect(onFileOpened).toHaveBeenCalledWith('/other/file.md', '# new file content');
     });
+  });
+});
+
+// ============================================================
+// handleLinkClick — in-document anchors
+// ============================================================
+
+describe('handleLinkClick — anchors', () => {
+  // Returns the scrollTo calls recorded for each container, in DOM order.
+  const buildPanes = (panes: Array<{ active?: boolean; html: string }>) => {
+    document.body.innerHTML = panes
+      .map(
+        (p) =>
+          `<div class="editor-pane${p.active ? ' active' : ''}">` +
+          `<div class="editor-container">${p.html}</div></div>`
+      )
+      .join('');
+    return Array.from(document.querySelectorAll<HTMLElement>('.editor-container')).map((c) => {
+      const calls: unknown[] = [];
+      c.scrollTo = ((arg: unknown) => calls.push(arg)) as typeof c.scrollTo;
+      return calls;
+    });
+  };
+
+  // Code+preview replaces the whole SplitContainer, so no .editor-pane exists.
+  const buildBareContainer = (html: string) => {
+    document.body.innerHTML = `<div class="split-editor-preview"><div class="editor-container">${html}</div></div>`;
+    const c = document.querySelector<HTMLElement>('.editor-container')!;
+    const calls: unknown[] = [];
+    c.scrollTo = ((arg: unknown) => calls.push(arg)) as typeof c.scrollTo;
+    return calls;
+  };
+
+  it('scrolls to an exactly matching heading id', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([{ active: true, html: '<h2 id="overview">Overview</h2>' }]);
+
+    handleLinkClick('#overview');
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('searches the active pane, not the first one in the DOM', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [inactive, active] = buildPanes([
+      { html: '<p>other document</p>' },
+      { active: true, html: '<h2 id="overview">Overview</h2>' },
+    ]);
+
+    handleLinkClick('#overview');
+
+    expect(inactive).toHaveLength(0);
+    expect(active).toHaveLength(1);
+  });
+
+  it('falls back to the plain container when no pane is marked active', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const calls = buildBareContainer('<h2 id="overview">Overview</h2>');
+
+    handleLinkClick('#overview');
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('resolves an anchor written against the old collapsed-hyphen slug rules', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([
+      { active: true, html: '<h2 id="tier-0--write-path-correctness">Tier 0 — write-path correctness</h2>' },
+    ]);
+
+    // What MerMark used to generate, and what users hand-patched their docs to.
+    handleLinkClick('#tier-0-write-path-correctness');
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('resolves against heading text when the id is stale after a WYSIWYG edit', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([
+      { active: true, html: '<h2 id="old-title">Renamed Section</h2>' },
+    ]);
+
+    handleLinkClick('#renamed-section');
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('decodes percent-encoded anchors', () => {
+    const { options } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([{ active: true, html: '<h2 id="概要">概要</h2>' }]);
+
+    handleLinkClick('#' + encodeURIComponent('概要'));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it('reports a genuinely missing anchor instead of failing silently', () => {
+    const onAnchorNotFound = vi.fn();
+    const { options } = makeOptions({}, { onAnchorNotFound });
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([{ active: true, html: '<h2 id="overview">Overview</h2>' }]);
+
+    handleLinkClick('#nothing-like-this');
+
+    expect(calls).toHaveLength(0);
+    expect(onAnchorNotFound).toHaveBeenCalledWith('nothing-like-this');
+  });
+
+  it('does not treat an anchor as a file to open', () => {
+    const { options, createNewTab } = makeOptions();
+    const { handleLinkClick } = useFileOperations(options as never);
+    buildPanes([{ active: true, html: '<p>no headings</p>' }]);
+
+    handleLinkClick('#missing');
+
+    expect(createNewTab).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/composables/useFileOperations.test.ts
+++ b/src/__tests__/composables/useFileOperations.test.ts
@@ -563,4 +563,59 @@ describe('handleLinkClick — anchors', () => {
 
     expect(createNewTab).not.toHaveBeenCalled();
   });
+
+  it('does not jump to an unrelated heading that carries a stale look-alike id', () => {
+    const onAnchorNotFound = vi.fn();
+    const { options } = makeOptions({}, { onAnchorNotFound });
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([
+      {
+        active: true,
+        html:
+          '<h2 id="foo--bar">Deprecated Notice</h2>' +
+          '<h2 id="foo-bar-2024">Foo Bar</h2>',
+      },
+    ]);
+
+    // jsdom gives every element a zero rect, so stub distinct offsets to make
+    // WHICH heading was chosen observable in the resulting scroll position.
+    const wrong = document.getElementById('foo--bar')!;
+    const right = document.getElementById('foo-bar-2024')!;
+    const container = document.querySelector('.editor-container')!;
+    container.getBoundingClientRect = (() => ({ top: 0 })) as never;
+    wrong.getBoundingClientRect = (() => ({ top: 100 })) as never;
+    right.getBoundingClientRect = (() => ({ top: 500 })) as never;
+
+    handleLinkClick('#foo-bar');
+
+    // Must land on the heading actually titled "Foo Bar" (500 - 20), never on
+    // the one that merely holds a stale double-hyphen id (which would be 80).
+    expect(calls).toEqual([{ top: 480, behavior: 'smooth' }]);
+    expect(onAnchorNotFound).not.toHaveBeenCalled();
+  });
+
+  it('reports ambiguity instead of guessing between two equally good headings', () => {
+    const onAnchorNotFound = vi.fn();
+    const { options } = makeOptions({}, { onAnchorNotFound });
+    const { handleLinkClick } = useFileOperations(options as never);
+    const [calls] = buildPanes([
+      { active: true, html: '<h2 id="a">Foo Bar</h2><h2 id="b">Foo  Bar</h2>' },
+    ]);
+
+    handleLinkClick('#foo-bar');
+
+    expect(calls).toHaveLength(0);
+    expect(onAnchorNotFound).toHaveBeenCalledWith('foo-bar');
+  });
+
+  it('does not throw on a malformed percent escape, and still reports it', () => {
+    const onAnchorNotFound = vi.fn();
+    const { options } = makeOptions({}, { onAnchorNotFound });
+    const { handleLinkClick } = useFileOperations(options as never);
+    buildPanes([{ active: true, html: '<h2 id="coverage">Coverage</h2>' }]);
+
+    expect(() => handleLinkClick('#100%-coverage')).not.toThrow();
+    expect(() => handleLinkClick('#a%zz')).not.toThrow();
+    expect(onAnchorNotFound).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -91,6 +91,37 @@ describe('generateSlug', () => {
   });
 });
 
+describe('heading slugs from inline markdown', () => {
+  const idOf = (md: string) => markdownToHtml(md, []).match(/<h\d id="([^"]*)"/)![1];
+
+  it('uses link text, not the URL, for a plain link heading', () => {
+    expect(idOf('## [Getting Started](./setup.md) notes')).toBe('getting-started-notes');
+  });
+
+  it('handles nested brackets in link text', () => {
+    // A `[^\]]+` link text fails to match this and leaks the whole raw link.
+    expect(idOf('## [a [b] c](url)')).toBe('a-b-c');
+  });
+
+  it('treats a code span as literal, not as emphasis', () => {
+    // GitHub keeps both spaces left by the stripped '*', so each becomes a hyphen.
+    expect(idOf('## `1 * 2 * 3`')).toBe('1--2--3');
+  });
+
+  it('treats a code span as literal, not as a link', () => {
+    expect(idOf('## `[not a link](file.txt)`')).toBe('not-a-linkfiletxt');
+  });
+
+  it('does not corrupt a heading whose own text contains digits', () => {
+    // Regression: a digit-delimited code-span placeholder clobbered "1".
+    expect(idOf('## Step 1 of 3 uses `npm run build`')).toBe('step-1-of-3-uses-npm-run-build');
+  });
+
+  it('strips bold and strikethrough', () => {
+    expect(idOf('## **Bold** and ~~gone~~ text')).toBe('bold-and-gone-text');
+  });
+});
+
 describe('createHeadingSlugger', () => {
   it('numbers duplicates the way GitHub does', () => {
     const slugger = createHeadingSlugger();

--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -3,6 +3,7 @@ import {
   decodeHtmlEntities,
   escapeHtml,
   generateSlug,
+  createHeadingSlugger,
   htmlToMarkdown,
   markdownToHtml,
   detectLineEnding,
@@ -62,12 +63,48 @@ describe('generateSlug', () => {
     expect(generateSlug('Hello! World?')).toBe('hello-world');
   });
 
-  it('replaces spaces with hyphens', () => {
-    expect(generateSlug('multiple   spaces')).toBe('multiple-spaces');
+  // Each space becomes its own hyphen — runs are NOT collapsed. This is what
+  // GitHub does, and collapsing them is what broke em-dash headings: the dash
+  // is dropped but the spaces on either side of it are not.
+  it('gives every space its own hyphen', () => {
+    expect(generateSlug('multiple   spaces')).toBe('multiple---spaces');
   });
 
-  it('handles Polish characters', () => {
-    expect(generateSlug('Architecture Decision')).toBe('architecture-decision');
+  it('matches GitHub for an em-dash heading', () => {
+    expect(generateSlug('Tier 0 — write-path correctness')).toBe('tier-0--write-path-correctness');
+  });
+
+  it('matches GitHub for an ampersand heading', () => {
+    expect(generateSlug('FAQ & Notes')).toBe('faq--notes');
+  });
+
+  it('preserves Polish diacritics', () => {
+    expect(generateSlug('Architektura Decyzji Ważnej')).toBe('architektura-decyzji-ważnej');
+  });
+
+  it('preserves CJK headings instead of producing an empty id', () => {
+    expect(generateSlug('概要')).toBe('概要');
+  });
+
+  it('preserves underscores', () => {
+    expect(generateSlug('api_key_rotation')).toBe('api_key_rotation');
+  });
+});
+
+describe('createHeadingSlugger', () => {
+  it('numbers duplicates the way GitHub does', () => {
+    const slugger = createHeadingSlugger();
+    expect(slugger.slug('Foo')).toBe('foo');
+    expect(slugger.slug('Foo')).toBe('foo-1');
+    expect(slugger.slug('Foo')).toBe('foo-2');
+  });
+
+  it('never hands a generated id to a heading that already claimed it', () => {
+    const slugger = createHeadingSlugger();
+    expect(slugger.slug('Foo')).toBe('foo');
+    expect(slugger.slug('Foo 1')).toBe('foo-1');
+    // Naive per-root numbering would emit 'foo-1' here and collide above.
+    expect(slugger.slug('Foo')).toBe('foo-2');
   });
 });
 

--- a/src/__tests__/utils/markdown-converter.test.ts
+++ b/src/__tests__/utils/markdown-converter.test.ts
@@ -37,6 +37,19 @@ describe('decodeHtmlEntities', () => {
   it('handles mixed content', () => {
     expect(decodeHtmlEntities('Hello &amp; goodbye &rarr; see you!')).toBe('Hello & goodbye → see you!');
   });
+
+  // An out-of-range code point used to throw RangeError out of the whole
+  // markdown conversion, so one bad entity blanked the document.
+  it('leaves an out-of-range code point as written instead of throwing', () => {
+    expect(decodeHtmlEntities('&#x110000;')).toBe('&#x110000;');
+    expect(decodeHtmlEntities('&#1114112;')).toBe('&#1114112;');
+    expect(decodeHtmlEntities('&#x7FFFFFFFFFFFFFFF;')).toBe('&#x7FFFFFFFFFFFFFFF;');
+    expect(decodeHtmlEntities('ok &#x110000; still &#x2192;')).toBe('ok &#x110000; still →');
+  });
+
+  it('still decodes the highest valid code point', () => {
+    expect(decodeHtmlEntities('&#x10FFFF;')).toBe(String.fromCodePoint(0x10ffff));
+  });
 });
 
 describe('escapeHtml', () => {

--- a/src/composables/useFileOperations.ts
+++ b/src/composables/useFileOperations.ts
@@ -347,11 +347,14 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
   };
 
   /**
-   * The pane the user is actually looking at. Split view and code+preview both
-   * put several `.editor-container` elements in the document, and taking the
-   * first one in DOM order used to search the wrong pane. The fallback is
-   * required, not defensive: in code+preview mode the whole SplitContainer is
-   * replaced and no `.editor-pane` ancestor exists at all. Same order as
+   * The pane the user is actually looking at. Split view puts several
+   * `.editor-container` elements in the document and taking the first in DOM
+   * order searched the wrong pane.
+   *
+   * The fallback covers layouts with no `.editor-pane` ancestor — code+preview
+   * replaces the whole SplitContainer. Note that mode's preview pane does not
+   * currently bind `@link-click` at all, so clicks there never reach this
+   * function; the fallback is for robustness, not for that mode. Same order as
    * usePdfExport and App.vue's scroll helpers.
    */
   const findEditorContainer = (): Element | null =>
@@ -363,12 +366,25 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
     value.toLowerCase().replace(/-+/g, '-').replace(/^-|-$/g, '');
 
   /**
-   * Exact id first, then a tolerant match. The fallback matters because ids are
-   * recomputed from heading text on every open, while `[](#anchor)` links are
-   * stored verbatim in the file — so anchors written against another renderer,
-   * or against MerMark's own older slug rules, would otherwise be dead forever.
-   * Matching heading text too covers headings edited in WYSIWYG, whose id is
-   * stale until the next save/reopen.
+   * Exact id first, then a tolerant match against heading TEXT.
+   *
+   * The fallback matters because ids are recomputed from heading text on every
+   * open while `[](#anchor)` links are stored verbatim in the file, so anchors
+   * written against another renderer — or against MerMark's own older slug
+   * rules — would otherwise be dead forever. It also covers headings renamed in
+   * WYSIWYG, whose id stays stale until the next save.
+   *
+   * Two deliberate restrictions keep it from guessing:
+   *
+   * Heading *ids* are not compared loosely. Doing so let an unrelated heading
+   * that merely happens to carry a stale double-hyphen id win on DOM order over
+   * the heading the link actually names, silently scrolling to the wrong
+   * section. Text is the thing the author wrote the anchor against, so text is
+   * what gets matched.
+   *
+   * An ambiguous match resolves to nothing. If two headings both normalise to
+   * the target, picking the first is a coin flip; reporting it as unresolved is
+   * honest and the user sees a toast rather than a plausible wrong jump.
    */
   const findAnchorTarget = (container: Element, targetId: string): HTMLElement | null => {
     const exact = Array.from(container.querySelectorAll<HTMLElement>('[id]'))
@@ -378,17 +394,25 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
     const wanted = looseAnchorKey(targetId);
     if (!wanted) return null;
 
-    return Array.from(container.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6'))
-      .find((heading) =>
-        looseAnchorKey(heading.id) === wanted ||
-        looseAnchorKey(generateSlug(heading.textContent ?? '')) === wanted
-      ) ?? null;
+    const matches = Array.from(container.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6'))
+      .filter((heading) => looseAnchorKey(generateSlug(heading.textContent ?? '')) === wanted);
+
+    return matches.length === 1 ? matches[0] : null;
   };
 
   const handleLinkClick = (href: string): void => {
     // Anchor link (internal navigation)
     if (href.startsWith('#')) {
-      const targetId = decodeURIComponent(href.slice(1));
+      // decodeURIComponent throws on a lone '%' — '#100%-coverage' is a real
+      // anchor, and an uncaught throw here would skip the not-found toast and
+      // restore exactly the silent no-op this whole change removes.
+      const raw = href.slice(1);
+      let targetId = raw;
+      try {
+        targetId = decodeURIComponent(raw);
+      } catch {
+        targetId = raw;
+      }
       const editorContainer = findEditorContainer();
       const targetElement = editorContainer ? findAnchorTarget(editorContainer, targetId) : null;
       if (targetElement && editorContainer) {

--- a/src/composables/useFileOperations.ts
+++ b/src/composables/useFileOperations.ts
@@ -2,7 +2,7 @@ import { ref, computed, type Ref, type ComputedRef } from 'vue';
 import { open, save } from '@tauri-apps/plugin-dialog';
 import { readTextFile, writeTextFile, rename, remove } from '@tauri-apps/plugin-fs';
 import { open as openExternal } from '@tauri-apps/plugin-shell';
-import { htmlToMarkdown, markdownToHtml, detectLineEnding, applyLineEnding } from '../utils/markdown-converter';
+import { htmlToMarkdown, markdownToHtml, detectLineEnding, applyLineEnding, generateSlug } from '../utils/markdown-converter';
 import { aiCommands } from '../services/aiCommands';
 import type { Tab } from './useTabs';
 import { EMPTY_TAB_CONTENT, DEFAULT_FILE_NAME, DOM_SELECTORS } from '../constants';
@@ -29,6 +29,9 @@ export interface UseFileOperationsOptions {
   /** Returns 'save' | 'cancel' | mergedMarkdownString (to save the merged version).
    *  localMarkdown is the current editor content (used to compute a local→disk diff). */
   onPreSaveConflict?: (filePath: string, diskContent: string, localMarkdown: string) => Promise<'save' | 'cancel' | string>;
+  /** Called when a `#anchor` link matches no heading, so the host can tell the
+   *  user instead of leaving the click looking like a no-op. */
+  onAnchorNotFound?: (anchor: string) => void;
 }
 
 export interface UseFileOperationsReturn {
@@ -62,6 +65,7 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
     onAfterSave,
     onFileOpened,
     onPreSaveConflict,
+    onAnchorNotFound,
   } = options;
 
   const currentFile = computed(() => activeTab.value?.filePath || null);
@@ -342,17 +346,59 @@ export function useFileOperations(options: UseFileOperationsOptions): UseFileOpe
     }
   };
 
+  /**
+   * The pane the user is actually looking at. Split view and code+preview both
+   * put several `.editor-container` elements in the document, and taking the
+   * first one in DOM order used to search the wrong pane. The fallback is
+   * required, not defensive: in code+preview mode the whole SplitContainer is
+   * replaced and no `.editor-pane` ancestor exists at all. Same order as
+   * usePdfExport and App.vue's scroll helpers.
+   */
+  const findEditorContainer = (): Element | null =>
+    document.querySelector(DOM_SELECTORS.ACTIVE_EDITOR_CONTAINER) ??
+    document.querySelector(DOM_SELECTORS.EDITOR_CONTAINER);
+
+  /** Ignore differences that only come from a slugger disagreeing about separators. */
+  const looseAnchorKey = (value: string): string =>
+    value.toLowerCase().replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+  /**
+   * Exact id first, then a tolerant match. The fallback matters because ids are
+   * recomputed from heading text on every open, while `[](#anchor)` links are
+   * stored verbatim in the file — so anchors written against another renderer,
+   * or against MerMark's own older slug rules, would otherwise be dead forever.
+   * Matching heading text too covers headings edited in WYSIWYG, whose id is
+   * stale until the next save/reopen.
+   */
+  const findAnchorTarget = (container: Element, targetId: string): HTMLElement | null => {
+    const exact = Array.from(container.querySelectorAll<HTMLElement>('[id]'))
+      .find((el) => el.id === targetId);
+    if (exact) return exact;
+
+    const wanted = looseAnchorKey(targetId);
+    if (!wanted) return null;
+
+    return Array.from(container.querySelectorAll<HTMLElement>('h1, h2, h3, h4, h5, h6'))
+      .find((heading) =>
+        looseAnchorKey(heading.id) === wanted ||
+        looseAnchorKey(generateSlug(heading.textContent ?? '')) === wanted
+      ) ?? null;
+  };
+
   const handleLinkClick = (href: string): void => {
     // Anchor link (internal navigation)
     if (href.startsWith('#')) {
-      const targetId = href.slice(1);
-      const editorContainer = document.querySelector(DOM_SELECTORS.EDITOR_CONTAINER);
-      const targetElement = editorContainer?.querySelector(`[id="${targetId}"]`) as HTMLElement | null;
+      const targetId = decodeURIComponent(href.slice(1));
+      const editorContainer = findEditorContainer();
+      const targetElement = editorContainer ? findAnchorTarget(editorContainer, targetId) : null;
       if (targetElement && editorContainer) {
         const containerRect = editorContainer.getBoundingClientRect();
         const elementRect = targetElement.getBoundingClientRect();
         const scrollOffset = elementRect.top - containerRect.top + editorContainer.scrollTop - 20;
         editorContainer.scrollTo({ top: scrollOffset, behavior: 'smooth' });
+      } else {
+        // Used to return silently, which is indistinguishable from a dead app.
+        onAnchorNotFound?.(targetId);
       }
       return;
     }

--- a/src/composables/useFileReload.ts
+++ b/src/composables/useFileReload.ts
@@ -178,6 +178,7 @@ export function useFileReload(options: UseFileReloadOptions) {
 
   return {
     // Toast
+    showToastNotification,
     showToast: computed(() => showToast.value),
     toastMessage: computed(() => toastMessage.value),
     toastType: computed(() => toastType.value),

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -271,6 +271,7 @@ export interface Translations {
   preSaveConflictMessage: string;
   saveAnyway: string;
   fileDeletedExternally: (fileName: string) => string;
+  anchorNotFound: (anchor: string) => string;
 
   // Table of Contents
   tableOfContents: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -265,6 +265,7 @@ const en: Translations = {
   preSaveConflictMessage: 'The file has been modified externally since you last loaded or saved it.',
   saveAnyway: 'Save Anyway',
   fileDeletedExternally: (fileName: string) => `"${fileName}" was deleted externally.`,
+  anchorNotFound: (anchor: string) => `No heading matches "#${anchor}".`,
 
   // Table of Contents
   tableOfContents: 'Table of Contents',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -265,6 +265,7 @@ const pl: Translations = {
   preSaveConflictMessage: 'Plik został zmodyfikowany zewnętrznie od ostatniego wczytania lub zapisania.',
   saveAnyway: 'Zapisz mimo to',
   fileDeletedExternally: (fileName: string) => `"${fileName}" został usunięty zewnętrznie.`,
+  anchorNotFound: (anchor: string) => `Żaden nagłówek nie pasuje do "#${anchor}".`,
 
   // Table of Contents
   tableOfContents: 'Spis treści',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -265,6 +265,7 @@ const zhCN: Translations = {
   preSaveConflictMessage: '自上次加载或保存以来，文件已被外部修改。',
   saveAnyway: '仍然保存',
   fileDeletedExternally: (fileName: string) => `"${fileName}" 已被外部删除。`,
+  anchorNotFound: (anchor: string) => `没有标题与 "#${anchor}" 匹配。`,
 
   // Table of Contents
   tableOfContents: '目录',

--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -1,3 +1,5 @@
+import GithubSlugger, { slug } from 'github-slugger';
+
 const HTML_ENTITIES: Record<string, string> = {
   '&nbsp;': ' ',
   '&amp;': '&',
@@ -47,11 +49,34 @@ export function escapeHtml(text: string): string {
     .replace(/>/g, '&gt;');
 }
 
+/**
+ * Heading id slug, byte-compatible with GitHub's anchors.
+ *
+ * Delegates to `github-slugger` — the same implementation GitHub uses — so a
+ * `[link](#anchor)` written against a GitHub-rendered document resolves here
+ * too. Rolling this by hand is what caused the original bug: a `\s+` collapse
+ * turned "Tier 0 — write-path correctness" into `tier-0-write-path-correctness`
+ * where GitHub yields `tier-0--write-path-correctness` (the em dash is dropped
+ * but both surrounding spaces survive as hyphens), and an ASCII-only character
+ * class silently mangled non-Latin headings ("概要" produced an empty id).
+ *
+ * Stateless: duplicate headings get the same slug. For a whole document use
+ * `createHeadingSlugger()` so collisions are numbered the way GitHub numbers
+ * them.
+ */
 export function generateSlug(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .trim();
+  return slug(text);
+}
+
+/**
+ * Per-document slugger. Feed it every heading in document order; repeats get
+ * GitHub's `-1`, `-2`, … suffixes, and the counter re-checks each candidate so
+ * a generated id can never collide with a literal heading that already claimed
+ * it (`Foo`, `Foo 1`, `Foo` → `foo`, `foo-1`, `foo-2`).
+ *
+ * Always create a fresh one per conversion — a shared instance would leak
+ * numbering between files and tabs.
+ */
+export function createHeadingSlugger(): GithubSlugger {
+  return new GithubSlugger();
 }

--- a/src/utils/html-entities.ts
+++ b/src/utils/html-entities.ts
@@ -22,6 +22,16 @@ const HTML_ENTITIES: Record<string, string> = {
   '&trade;': '™',
 };
 
+const MAX_CODE_POINT = 0x10ffff;
+
+// String.fromCodePoint throws RangeError above U+10FFFF, and `&#x110000;` is
+// something a document can legitimately contain. An uncaught throw here takes
+// down the whole conversion, so an out-of-range entity is left as written.
+const codePointToChar = (raw: string, radix: number, match: string): string => {
+  const code = parseInt(raw, radix);
+  return code > MAX_CODE_POINT ? match : String.fromCodePoint(code);
+};
+
 export function decodeHtmlEntities(text: string): string {
   let result = text;
 
@@ -30,13 +40,13 @@ export function decodeHtmlEntities(text: string): string {
   }
 
   // Hex entities: &#x1F600;
-  result = result.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) =>
-    String.fromCodePoint(parseInt(hex, 16))
+  result = result.replace(/&#x([0-9a-fA-F]+);/g, (match, hex) =>
+    codePointToChar(hex, 16, match)
   );
 
   // Decimal entities: &#128512;
-  result = result.replace(/&#(\d+);/g, (_, dec) =>
-    String.fromCodePoint(parseInt(dec, 10))
+  result = result.replace(/&#(\d+);/g, (match, dec) =>
+    codePointToChar(dec, 10, match)
   );
 
   return result;

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -2,7 +2,7 @@
  * Markdown converter - main entry point.
  * Re-exports from focused sub-modules for backward compatibility.
  */
-export { decodeHtmlEntities, escapeHtml, generateSlug } from './html-entities';
+export { decodeHtmlEntities, escapeHtml, generateSlug, createHeadingSlugger } from './html-entities';
 export { convertInlineToMarkdown, extractMermaidCode, parseHtmlList, processHtmlLists } from './html-to-markdown';
 export {
   parseMarkdownLists,

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, generateSlug } from './html-entities';
+import { escapeHtml, decodeHtmlEntities, createHeadingSlugger } from './html-entities';
 import {
   findAllMermaidMatches,
   getCurrentMermaidReadFormats,
@@ -235,15 +235,46 @@ export function convertMarkdownTables(html: string): string {
   });
 }
 
-export function convertMarkdownHeaders(html: string): string {
-  let result = html;
-  result = result.replace(/^###### (.*$)/gim, (_, content) => `<h6 id="${generateSlug(content)}">${content}</h6>`);
-  result = result.replace(/^##### (.*$)/gim, (_, content) => `<h5 id="${generateSlug(content)}">${content}</h5>`);
-  result = result.replace(/^#### (.*$)/gim, (_, content) => `<h4 id="${generateSlug(content)}">${content}</h4>`);
-  result = result.replace(/^### (.*$)/gim, (_, content) => `<h3 id="${generateSlug(content)}">${content}</h3>`);
-  result = result.replace(/^## (.*$)/gim, (_, content) => `<h2 id="${generateSlug(content)}">${content}</h2>`);
-  result = result.replace(/^# (.*$)/gim, (_, content) => `<h1 id="${generateSlug(content)}">${content}</h1>`);
-  return result;
+/**
+ * Visible text of a heading, as a reader sees it — the basis for its slug.
+ *
+ * Two reasons this can't just be the raw ATX line body. The line arrives here
+ * already HTML-escaped (`escapeHtml` runs earlier in the pipeline), so "Q&A" is
+ * "Q&amp;A" and would slug to `qampa`. And headers are converted *before*
+ * inline formatting, so `## [Getting Started](./setup.md) notes` would otherwise
+ * slug the URL into the id.
+ *
+ * Only the inline syntax `convertMarkdownFormatting` actually handles is
+ * stripped. Underscores are deliberately left alone: they're legal in slugs
+ * (`api_key_rotation`), this converter has never treated `_` as emphasis, and
+ * CommonMark forbids intraword `_` emphasis anyway.
+ */
+export function headingDisplayText(escapedContent: string): string {
+  return decodeHtmlEntities(escapedContent)
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')  // images -> alt text
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')   // links  -> link text
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .trim();
+}
+
+/**
+ * One top-to-bottom pass over every heading level. It has to be a single pass:
+ * duplicate-id numbering must follow document order, and the previous
+ * level-by-level passes (h6 first, h1 last) numbered them in level order, so
+ * `# Foo` above `## Foo` got the suffix rather than the heading below it.
+ *
+ * `slugger` defaults to a fresh instance per call, which is the correct scope —
+ * one document conversion.
+ */
+export function convertMarkdownHeaders(html: string, slugger = createHeadingSlugger()): string {
+  return html.replace(/^(#{1,6}) (.*)$/gm, (_, hashes: string, content: string) => {
+    const level = hashes.length;
+    const id = slugger.slug(headingDisplayText(content));
+    return `<h${level} id="${id}">${content}</h${level}>`;
+  });
 }
 
 export function convertMarkdownFormatting(html: string): string {

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -250,14 +250,38 @@ export function convertMarkdownTables(html: string): string {
  * CommonMark forbids intraword `_` emphasis anyway.
  */
 export function headingDisplayText(escapedContent: string): string {
-  return decodeHtmlEntities(escapedContent)
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')  // images -> alt text
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')   // links  -> link text
-    .replace(/\*\*([^*]+)\*\*/g, '$1')
-    .replace(/\*([^*]+)\*/g, '$1')
-    .replace(/~~([^~]+)~~/g, '$1')
-    .replace(/`([^`]+)`/g, '$1')
-    .trim();
+  let text = escapedContent.includes('&') ? decodeHtmlEntities(escapedContent) : escapedContent;
+
+  // Code spans are opaque in CommonMark — their contents are literal and must
+  // never be reinterpreted as other inline syntax. Mask them before anything
+  // else runs, or `` `1 * 2 * 3` `` loses its asterisks to the emphasis rule
+  // and `` `[not a link](x)` `` loses its target to the link rule.
+  // NUL-delimited: a bare-digit marker would be clobbered on restore by a
+  // heading that contains its own numbers, e.g. "Step 1 of 3".
+  const codeSpans: string[] = [];
+  if (text.includes('`')) {
+    text = text.replace(/`([^`]+)`/g, (_, code: string) => `\u0000${codeSpans.push(code) - 1}\u0000`);
+  }
+
+  if (text.includes('[')) {
+    text = text
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')                    // images -> alt text
+      // One level of nested brackets is allowed: `[a [b] c](url)` is valid
+      // CommonMark, and a `[^\]]+` link text would fail to match it and leak
+      // the whole raw link — URL included — into the slug.
+      .replace(/\[((?:[^[\]]|\[[^\]]*\])*)\]\([^)]*\)/g, '$1');    // links  -> link text
+  }
+  if (text.includes('*')) {
+    text = text.replace(/\*\*([^*]+)\*\*/g, '$1').replace(/\*([^*]+)\*/g, '$1');
+  }
+  if (text.includes('~~')) {
+    text = text.replace(/~~([^~]+)~~/g, '$1');
+  }
+
+  return (codeSpans.length
+    ? text.replace(/\u0000(\d+)\u0000/g, (_, i: string) => codeSpans[Number(i)])
+    : text
+  ).trim();
 }
 
 /**


### PR DESCRIPTION
Fixes #131.

Clicking `[Section](#section)` did nothing — no scroll, no error, no console output — whenever the heading id MerMark generated differed from the anchor the author wrote. On a real 700-line document with em-dash headings, 131 of 182 anchor links were dead.

## Root cause

`generateSlug` was hand-rolled and diverged from GitHub's slugging in four ways:

| Heading | id before | GitHub anchor |
|---|---|---|
| `Tier 0 — write-path correctness` | `tier-0-write-path-correctness` | `tier-0--write-path-correctness` |
| `FAQ & Notes` | `faq-amp-notes` | `faq--notes` |
| `Übersicht` | `bersicht` | `übersicht` |
| `概要` | *(empty string)* | `概要` |

1. `.replace(/\s+/g,'-')` collapsed whitespace runs. GitHub replaces each space individually, so a stripped em dash leaves *two* hyphens.
2. `escapeHtml` runs before heading conversion, so slugs were built from `FAQ &amp; Notes`.
3. `[^\w\s-]` is ASCII-only, dropping non-Latin letters entirely. This affects the `pl` and `zh-CN` locales the project already ships.
4. Duplicate headings produced duplicate ids, so those links always jumped to the first one.

## Approach

Rather than patch the regex, slugging now delegates to [`github-slugger`](https://github.com/Flet/github-slugger) — the package GitHub itself uses. That brings the exact strip table and the collision numbering, whose counter re-checks each candidate so a generated `foo-1` cannot collide with a heading literally titled "Foo 1".

**This adds one runtime dependency** (MIT, no transitive deps, ~16 KB). Happy to hand-roll the algorithm instead if you'd rather not take it — the trade-off is ongoing divergence from GitHub on rarer inputs. Say the word and I'll rework it.

Two supporting changes were required:

- `convertMarkdownHeaders` became a single top-to-bottom pass. It ran one pass per heading level, h6 first, so duplicate numbering would have followed level order rather than document order.
- Slugs are computed from the heading's visible text. The raw ATX line arrives HTML-escaped and before inline formatting is stripped, so a link inside a heading leaked its URL into the id.

## Anchor resolution

Ids are recomputed on every open while `#anchor` links are stored verbatim in the file, so resolution is now more forgiving:

- Look in the **active** pane. Split view puts several `.editor-container` elements in the document and the first in DOM order was searched, so anchors were dead whenever a second pane was open.
- Fall back to a separator-insensitive match against heading **text**, keeping documents written against the old slug rules working. An ambiguous match resolves to nothing rather than guessing.
- Report a genuinely missing anchor via a toast instead of returning silently.

## Notes

- Underscores are deliberately preserved (`api_key_rotation`) — valid in GitHub slugs, and this converter has never treated `_` as emphasis.
- No version bump or release notes, since those look like your release step rather than a contributor's. Happy to add them if you'd prefer.
- The second commit fixes defects found during review of the first (wrong-heading navigation via the tolerant fallback, an uncaught `decodeURIComponent` throw on `#100%-coverage`, code spans not being treated as opaque, and a ~5x header-parsing regression now back at parity). Kept separate so the history is honest — squash if you prefer.

## Not addressed

Both pre-existing and out of scope here:

- Heading ids are not recomputed while editing in WYSIWYG, so a renamed heading's id is stale until save + reopen. The new text-based fallback hides this in practice.
- The code+preview live-preview pane binds no `@link-click`, so link clicks there never reach this code at all.

## Testing

`pnpm test:run` — 1089 passing, up from 1066 on master. New coverage for the slug cases above, duplicate numbering, the active-pane lookup and its fallback, malformed percent escapes, and each review defect (all of which fail against the preceding commit). `pnpm build` and `vue-tsc --noEmit` clean.

Also verified manually in the running app: the ids above are produced live, each anchor scrolls to its heading, and a dead anchor raises the toast.