### PR TITLE
fix: render updater screenshots and prepare v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,34 @@
 
 ---
 
+# Release v0.7.1 — Release screenshots display correctly
+
+![MerMark v0.7 — Markdown syntax highlighting in Code View](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png)
+
+![MerMark v0.7 — README HTML rendered in Visual Mode](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png)
+
+## Bug fixes
+
+- Fixed screenshots in the update dialog being displayed as raw `<p>` and `<img>` text instead of images.
+- Release screenshots now render consistently both inside MerMark and on GitHub.
+
+## v0.7 highlights
+
+- Open and edit multi-megabyte Markdown in responsive, editable Visual Mode.
+- See Markdown and README HTML syntax highlighted in Code View.
+- Render common README HTML directly in Visual Mode without rewriting its source.
+- Move between Visual and Code views without losing the corresponding line.
+- Open saved Linux workspaces inside dot-prefixed directories after restarting MerMark.
+
+---
+
 # Release v0.7.0 — Big files, richer code, polished READMEs
 
 Open and edit multi-megabyte Markdown without freezing, see Markdown structure clearly in Code View, and render common README HTML directly in Visual Mode.
 
-<p>
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png" alt="MerMark v0.7.0 — Markdown syntax highlighting in Code View" width="48%" />
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png" alt="MerMark v0.7.0 — README HTML rendered in Visual Mode" width="48%" />
-</p>
+![MerMark v0.7.0 — Markdown syntax highlighting in Code View](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png)
+
+![MerMark v0.7.0 — README HTML rendered in Visual Mode](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png)
 
 ## Features
 

--- a/docs/release-notes/v0.7.0/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.7.0/RELEASE_NOTES.md
@@ -2,10 +2,9 @@
 
 Open and edit multi-megabyte Markdown without freezing, see Markdown structure clearly in Code View, and render common README HTML directly in Visual Mode.
 
-<p>
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png" alt="MerMark v0.7.0 — Markdown syntax highlighting in Code View" width="48%" />
-  <img src="https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png" alt="MerMark v0.7.0 — README HTML rendered in Visual Mode" width="48%" />
-</p>
+![MerMark v0.7.0 — Markdown syntax highlighting in Code View](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png)
+
+![MerMark v0.7.0 — README HTML rendered in Visual Mode](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png)
 
 ## Features
 

--- a/docs/release-notes/v0.7.1/RELEASE_NOTES.md
+++ b/docs/release-notes/v0.7.1/RELEASE_NOTES.md
@@ -1,0 +1,18 @@
+# Release v0.7.1 — Release screenshots display correctly
+
+![MerMark v0.7 — Markdown syntax highlighting in Code View](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/markdown-syntax-highlighting.png)
+
+![MerMark v0.7 — README HTML rendered in Visual Mode](https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/readme-html-rendering.png)
+
+## Bug fixes
+
+- Fixed screenshots in the update dialog being displayed as raw `<p>` and `<img>` text instead of images.
+- Release screenshots now render consistently both inside MerMark and on GitHub.
+
+## v0.7 highlights
+
+- Open and edit multi-megabyte Markdown in responsive, editable Visual Mode.
+- See Markdown and README HTML syntax highlighted in Code View.
+- Render common README HTML directly in Visual Mode without rewriting its source.
+- Move between Visual and Code views without losing the corresponding line.
+- Open saved Linux workspaces inside dot-prefixed directories after restarting MerMark.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mermark-editor",
   "private": false,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Modern Markdown editor with Mermaid diagram support",
   "author": "Vesperino",
   "license": "MIT",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdreader"
-version = "0.7.0"
+version = "0.7.1"
 description = "Markdown editor with Mermaid support"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MerMark Editor",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "com.mermark.editor",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/__tests__/components/UpdateDialog.test.ts
+++ b/src/__tests__/components/UpdateDialog.test.ts
@@ -25,6 +25,22 @@ describe('UpdateDialog', () => {
     expect(wrapper.html()).toContain('New features');
   });
 
+  it('renders release-note Markdown images instead of showing image syntax as text', () => {
+    const imageUrl = 'https://raw.githubusercontent.com/Vesperino/MerMarkEditor/master/assets/screenshots/example.png';
+    const wrapper = mount(UpdateDialog, {
+      props: {
+        version: '0.7.1',
+        notes: `![Code View screenshot](${imageUrl})`,
+      },
+    });
+
+    const image = wrapper.find<HTMLImageElement>('.update-notes img');
+    expect(image.exists()).toBe(true);
+    expect(image.attributes('src')).toBe(imageUrl);
+    expect(image.attributes('alt')).toBe('Code View screenshot');
+    expect(wrapper.find('.update-notes').text()).not.toContain('![');
+  });
+
   it('hides notes section when notes are empty', () => {
     const wrapper = mount(UpdateDialog, {
       props: { version: '0.1.72', notes: '' },

--- a/src/components/UpdateDialog.vue
+++ b/src/components/UpdateDialog.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue';
 import { markdownToHtml } from '../utils/markdown-converter';
 import { useI18n } from '../i18n';
+import '../styles/release-notes.css';
 
 const { t } = useI18n();
 
@@ -50,7 +51,7 @@ const emit = defineEmits<{
             </svg>
             <span>{{ t.whatsNew || "What's new" }}</span>
           </button>
-          <div v-show="notesExpanded" class="update-notes whats-new-content" v-html="notesHtml"></div>
+          <div v-show="notesExpanded" class="update-notes release-notes-content" v-html="notesHtml"></div>
         </div>
         <div v-if="isUpdating" class="update-progress">
           <p>{{ t.downloadingUpdate }}</p>


### PR DESCRIPTION
## What changed

- replaces raw HTML screenshot markup with standard Markdown images in the v0.7.0 and v0.7.1 release notes
- gives the updater dialog the same image-safe responsive styling as the built-in release history
- adds regression coverage proving Markdown screenshots become real `<img>` elements instead of visible source text
- bumps the application from v0.7.0 to v0.7.1 across the web and Tauri manifests
- regenerates the changelog and prepares complete v0.7.1 release notes

The already-published v0.7.0 GitHub Release description has also been corrected, so existing installations receive the fixed Markdown notes through the updater fallback immediately.

## Verification

- `pnpm test:run` — 1143 passed
- `pnpm build` — passed
- focused updater and Markdown converter tests — 172 passed
