### PR TITLE
fix(ui): remove spurious editor scrollbars

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -932,6 +932,8 @@ defineExpose({
 <style>
 .editor-container {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overflow-x: hidden;
   background: var(--editor-container-bg);
@@ -939,6 +941,8 @@ defineExpose({
 
 .editor-content-wrapper {
   position: relative;
+  flex: 1 0 auto;
+  width: 100%;
   max-width: 900px;
   margin: 20px auto;
 }
@@ -955,19 +959,22 @@ defineExpose({
 
 .editor-content {
   background: var(--editor-content-bg);
+  display: flex;
+  flex-direction: column;
   /* User-tunable paddings (Settings → Editor → Padding). Defaults defined
      in useSettings; the var fallbacks here only matter on first paint
      before applyCssVars runs. */
   padding: var(--editor-pad-top, 16px) var(--editor-pad-x, 24px) var(--editor-pad-bottom, 32px);
-  min-height: calc(100vh - 180px);
+  min-height: 100%;
   box-shadow: var(--shadow-sm);
   border-radius: 4px;
 }
 
 .editor-content .tiptap {
+  flex: 1;
   outline: none !important;
   border: none !important;
-  min-height: 600px;
+  min-height: 0;
   text-align: left;
   font-family: var(--editor-font-family, inherit);
 }

--- a/src/components/TabBar.vue
+++ b/src/components/TabBar.vue
@@ -281,6 +281,8 @@ const handleBarMouseLeave = () => {
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border-primary);
   overflow-x: auto;
+  overflow-y: hidden;
+  flex-shrink: 0;
   min-height: 36px;
   padding: 0 8px;
 }

--- a/tests/e2e/editor-scrollbars.test.ts
+++ b/tests/e2e/editor-scrollbars.test.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from '@playwright/test';
+import { setupTauriMocks } from './helpers/tauri-mock';
+
+async function openBlankDocument(page: Page) {
+  await page.setViewportSize({ width: 1197, height: 797 });
+  await page.addInitScript(() => {
+    localStorage.setItem('mermark-settings', JSON.stringify({
+      ai: { enabled: true, hasSeenFirstRun: true, panelSide: 'right' },
+    }));
+  });
+  await setupTauriMocks(page);
+  await page.goto('/');
+  await expect(page.locator('.editor-pane.active .editor-content-wrapper')).toBeVisible({ timeout: 10_000 });
+}
+
+async function verticalOverflow(page: Page, selector: string) {
+  return page.locator(selector).evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    overflowY: getComputedStyle(element).overflowY,
+  }));
+}
+
+test('blank document has no vertical scrollbar', async ({ page }) => {
+  await openBlankDocument(page);
+
+  const tabBar = await verticalOverflow(page, '.editor-pane.active .tab-bar');
+  const editor = await verticalOverflow(page, '.editor-pane.active .editor-container');
+  expect(tabBar.overflowY).toBe('hidden');
+  expect(editor.scrollHeight).toBe(editor.clientHeight);
+
+  const writingSurfaceHeight = await page.locator('.editor-pane.active .tiptap').evaluate(
+    (element) => element.clientHeight,
+  );
+  expect(writingSurfaceHeight).toBeGreaterThan(400);
+});
+
+test('long document still scrolls in the document area', async ({ page }) => {
+  await openBlankDocument(page);
+  await page.locator('.editor-pane.active .tiptap').fill(
+    Array.from({ length: 80 }, (_, index) => `Line ${index + 1}`).join('\n'),
+  );
+
+  const editor = await verticalOverflow(page, '.editor-pane.active .editor-container');
+  expect(editor.overflowY).toBe('auto');
+  expect(editor.scrollHeight).toBeGreaterThan(editor.clientHeight);
+});


### PR DESCRIPTION
## Summary

- Prevent the horizontal tab strip from acquiring a vertical scrollbar.
- Size an empty writing surface from the actual editor viewport instead of combining viewport and fixed minimum heights.
- Preserve normal document-area scrolling for long Markdown files.

## Problem

An empty document could show a vertical document scrollbar even though it had no content. The tab strip could also show a vertical scrollbar because `overflow-x: auto` implicitly made vertical overflow automatic.

## Implementation

- Make the editor container and writing surface a column flex layout that fills the available editor viewport.
- Remove the fixed 600px editable-area minimum and the viewport-based page minimum.
- Explicitly hide vertical overflow in the horizontal tab strip and prevent it from shrinking.

## Test plan

- [x] Full frontend suite: 86 files / 1,142 tests.
- [x] Type-check with `vue-tsc --noEmit`.
- [x] Production Vite build.
- [x] Chromium regression test: blank document has no vertical overflow.
- [x] Chromium regression test: long documents still scroll normally.

🤖 Generated with Codex.
