### PR TITLE
fix(ui): center documents beside the AI panel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1186,9 +1186,16 @@ const showSettingsModal = ref(false);
 
 // ============ AI Panel ============
 const aiPanelOpen = ref(false);
+const aiPanelReservedSide = ref<'left' | 'right' | null>(null);
 
 function toggleAiPanel() {
   aiPanelOpen.value = !aiPanelOpen.value;
+  if (!aiPanelOpen.value) aiPanelReservedSide.value = null;
+}
+
+function closeAiPanel() {
+  aiPanelOpen.value = false;
+  aiPanelReservedSide.value = null;
 }
 
 // Auto-open the panel whenever a Mermaid node registers an AI edit target.
@@ -2111,7 +2118,13 @@ onUnmounted(async () => {
     />
 
     <!-- Main content area with optional left bar -->
-    <div class="main-area">
+    <div
+      class="main-area"
+      :class="{
+        'main-area--reserve-ai-left': aiPanelReservedSide === 'left',
+        'main-area--reserve-ai-right': aiPanelReservedSide === 'right',
+      }"
+    >
       <!-- Workspace Sidebar (folder browser).
            Visible whenever the sidebar toggle is on — the sidebar renders an
            empty-state CTA when no workspace is open yet. -->
@@ -2406,7 +2419,8 @@ onUnmounted(async () => {
       @close="documentSearch.close"
     />
 
-    <!-- AI Assistant Panel (slide-in chat) -->
+    <!-- AI Assistant Panel (fixed overlay; reports whether main content should
+         reserve its width while the panel is neither minimized nor fullscreen) -->
     <AiPanel
       v-if="aiPanelOpen"
       :open="aiPanelOpen"
@@ -2417,7 +2431,8 @@ onUnmounted(async () => {
       :work-dir="aiWorkDir"
       :workspace-name="aiWorkspaceName"
       :workspace-root="aiWorkspaceRoot"
-      @close="aiPanelOpen = false"
+      @close="closeAiPanel"
+      @layout-change="aiPanelReservedSide = $event"
       @apply-content="onAiApplyContent"
       @show-diff="onAiShowDiff"
       @link-click="handleLinkClick"
@@ -2507,6 +2522,7 @@ onUnmounted(async () => {
 
 <style scoped>
 .app {
+  --ai-panel-width: 420px;
   display: flex;
   flex-direction: column;
   height: 100vh;
@@ -2518,6 +2534,16 @@ onUnmounted(async () => {
   flex: 1;
   overflow: hidden;
   min-height: 0;
+}
+
+/* Keep the fixed AI panel from covering editor content. AiPanel reports no
+   reserved side while minimized, fullscreen, disabled, or closed. */
+.main-area--reserve-ai-right {
+  padding-right: var(--ai-panel-width);
+}
+
+.main-area--reserve-ai-left {
+  padding-left: var(--ai-panel-width);
 }
 
 .editor-area {

--- a/src/__tests__/composables/useAiPanelLayout.test.ts
+++ b/src/__tests__/composables/useAiPanelLayout.test.ts
@@ -91,6 +91,21 @@ describe('useAiPanelLayout', () => {
     wrapper.unmount();
   });
 
+  it('reserves its configured side only in normal panel mode', () => {
+    const { api, wrapper } = setup({ panelSide: 'left' });
+    expect(api.reservedSide.value).toBe('left');
+
+    api.minimized.value = true;
+    expect(api.reservedSide.value).toBeNull();
+
+    api.minimized.value = false;
+    api.fullscreen.value = true;
+    expect(api.reservedSide.value).toBeNull();
+
+    api.unmount();
+    wrapper.unmount();
+  });
+
   it('Escape exits fullscreen instead of closing', () => {
     const onClose = vi.fn();
     const { api, wrapper } = setup({ onClose });

--- a/src/components/ai/AiPanel.vue
+++ b/src/components/ai/AiPanel.vue
@@ -44,6 +44,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: [];
+  layoutChange: [side: 'left' | 'right' | null];
   applyContent: [content: string];
   showDiff: [orig: string, candidate: string];
   linkClick: [url: string];
@@ -161,6 +162,13 @@ const layout = useAiPanelLayout({
     return false;
   },
 });
+
+const reservedSide = computed<'left' | 'right' | null>(() => {
+  if (!props.open || !settings.value.ai.enabled) return null;
+  return layout.reservedSide.value;
+});
+
+watch(reservedSide, (side) => emit('layoutChange', side), { immediate: true });
 
 const availableClis = computed<CliKind[]>(() => {
   const out: CliKind[] = [];
@@ -648,7 +656,7 @@ function onPreviewImage(img: PendingImage) {
   position: fixed;
   top: var(--toolbar-height, 44px);
   bottom: 0;
-  width: 420px;
+  width: var(--ai-panel-width, 420px);
   background: var(--bg-primary);
   color: var(--text-primary);
   border-left: 1px solid var(--border-primary);

--- a/src/composables/useAiPanelLayout.ts
+++ b/src/composables/useAiPanelLayout.ts
@@ -58,6 +58,11 @@ export function useAiPanelLayout(opts: AiPanelLayoutOptions) {
     return { ...base, top: `${topOffset.value}px` };
   });
 
+  const reservedSide = computed<'left' | 'right' | null>(() => {
+    if (fullscreen.value || minimized.value) return null;
+    return opts.panelSide();
+  });
+
   const minimizedStyle = computed<Record<string, string>>(() => {
     return opts.panelSide() === 'left'
       ? { left: '0', right: 'auto', top: `${topOffset.value + 12}px` }
@@ -89,6 +94,7 @@ export function useAiPanelLayout(opts: AiPanelLayoutOptions) {
     minimized,
     topOffset,
     sideStyle,
+    reservedSide,
     minimizedStyle,
     mount,
     unmount,

--- a/tests/e2e/ai-panel-layout.test.ts
+++ b/tests/e2e/ai-panel-layout.test.ts
@@ -1,0 +1,71 @@
+import { expect, test, type Page } from '@playwright/test';
+import { setupTauriMocks } from './helpers/tauri-mock';
+
+const DOC_PATH = '/test/ai-panel-layout.md';
+const DOC_MARKDOWN = '# AI panel layout\n\nThe document should remain centred in the visible editor area.';
+
+async function openDocument(page: Page, panelSide: 'left' | 'right' = 'right') {
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.addInitScript((side: 'left' | 'right') => {
+    localStorage.setItem('mermark-settings', JSON.stringify({
+      ai: { enabled: true, hasSeenFirstRun: true, panelSide: side },
+    }));
+  }, panelSide);
+  await setupTauriMocks(page, {
+    initialFs: { [DOC_PATH]: DOC_MARKDOWN },
+    openFilePath: DOC_PATH,
+  });
+
+  await page.goto('/');
+  await expect(page.locator('.editor-pane.active .editor-content-wrapper')).toBeVisible({ timeout: 10_000 });
+}
+
+async function openAiPanel(page: Page) {
+  await page.getByRole('button', { name: 'Toggle AI assistant' }).first().click();
+  await expect(page.locator('.ai-panel')).toBeVisible();
+  await expect.poll(() => page.locator('.main-area').evaluate((element) => {
+    const style = getComputedStyle(element);
+    return parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+  })).toBeGreaterThan(0);
+}
+
+test.describe('AI panel layout', () => {
+  test('centres the document in the editor space left visible by the right panel', async ({ page }) => {
+    await openDocument(page);
+    await openAiPanel(page);
+
+    const geometry = await page.evaluate(() => {
+      const editor = document.querySelector('.editor-pane.active .editor-container');
+      const wrapper = document.querySelector('.editor-pane.active .editor-content-wrapper');
+      const panel = document.querySelector('.ai-panel');
+      if (!editor || !wrapper || !panel) throw new Error('Expected editor, document wrapper, and AI panel');
+
+      const editorRect = editor.getBoundingClientRect();
+      const wrapperRect = wrapper.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      return {
+        availableCenter: (editorRect.left + panelRect.left) / 2,
+        wrapperCenter: (wrapperRect.left + wrapperRect.right) / 2,
+        wrapperRight: wrapperRect.right,
+        panelLeft: panelRect.left,
+      };
+    });
+
+    expect(Math.abs(geometry.wrapperCenter - geometry.availableCenter)).toBeLessThanOrEqual(1);
+    expect(geometry.wrapperRight).toBeLessThanOrEqual(geometry.panelLeft);
+  });
+
+  test('reserves space on the left when the panel is configured on the left', async ({ page }) => {
+    await openDocument(page, 'left');
+    await openAiPanel(page);
+
+    const panelWidth = await page.locator('.ai-panel').evaluate(el => el.getBoundingClientRect().width);
+    const padding = await page.locator('.main-area').evaluate(el => {
+      const style = getComputedStyle(el);
+      return { left: parseFloat(style.paddingLeft), right: parseFloat(style.paddingRight) };
+    });
+
+    expect(Math.abs(padding.left - panelWidth)).toBeLessThanOrEqual(1);
+    expect(padding.right).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the document centred in the editor area that remains visible beside the fixed AI panel.
- Support both left- and right-side AI-panel settings.
- Release the reserved space when the panel is minimized, fullscreen, disabled, or closed.

## Problem

The AI assistant is a fixed 420px overlay, but the document continued to centre against the full window width. With the panel open, part of the document could sit underneath the overlay and the visible page appeared shifted to the right.

## Implementation

- Share the panel width through one CSS custom property.
- Let the AI panel report whether its configured side currently needs layout space.
- Apply matching main-area padding only while the normal panel is visible.

## Test plan

- [x] Full frontend suite: 86 files / 1,143 tests.
- [x] Type-check with `vue-tsc --noEmit`.
- [x] Production Vite build.
- [x] Chromium geometry test for a right-side panel.
- [x] Chromium geometry test for a left-side panel.
- [x] Unit coverage for normal, minimized, and fullscreen reservation states.

🤖 Generated with Codex.
