### PR TITLE
feat(ai): make startup CLI checks optional

### DIFF
--- a/src/__tests__/composables/useAiHealth.test.ts
+++ b/src/__tests__/composables/useAiHealth.test.ts
@@ -7,12 +7,14 @@ vi.mock('../../services/aiCommands', () => ({
 }));
 
 import { aiCommands } from '../../services/aiCommands';
-import { useAiHealth } from '../../composables/useAiHealth';
+import { readPersistedCliHealth, useAiHealth } from '../../composables/useAiHealth';
+import { useSettings } from '../../composables/useSettings';
 
 describe('useAiHealth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useAiHealth().reset();
+    useAiHealth().reset(true);
+    useSettings().setAiCheckCliHealthOnStartup(true);
   });
 
   it('caches the first result and does not re-call without force', async () => {
@@ -45,5 +47,51 @@ describe('useAiHealth', () => {
     const { checkAll } = useAiHealth();
     await checkAll();
     expect(aiCommands.healthCheck).toHaveBeenCalledWith('ollama', expect.anything());
+  });
+
+  it('checks Claude and Codex automatically by default', async () => {
+    (aiCommands.healthCheck as unknown as { mockResolvedValue: (v: unknown) => void })
+      .mockResolvedValue({ ok: true, version: '1', account: null, error: null, resolvedPath: null });
+
+    await useAiHealth().checkCliOnStartup();
+
+    expect(aiCommands.healthCheck).toHaveBeenCalledWith('claude', null);
+    expect(aiCommands.healthCheck).toHaveBeenCalledWith('codex', null);
+  });
+
+  it('skips Claude and Codex startup probes when the preference is disabled', async () => {
+    useSettings().setAiCheckCliHealthOnStartup(false);
+    (aiCommands.healthCheck as unknown as { mockResolvedValue: (v: unknown) => void })
+      .mockResolvedValue({ ok: true, version: '1', account: null, error: null, resolvedPath: null });
+
+    await useAiHealth().checkCliOnStartup();
+
+    expect(aiCommands.healthCheck).not.toHaveBeenCalled();
+  });
+
+  it('persists the last-known CLI status locally', async () => {
+    (aiCommands.healthCheck as unknown as { mockResolvedValue: (v: unknown) => void })
+      .mockResolvedValue({ ok: true, version: '1.2.3', account: 'me', error: null, resolvedPath: '/bin/claude' });
+
+    await useAiHealth().check('claude', true);
+
+    const stored = JSON.parse(localStorage.getItem('mermark-ai-cli-health') ?? '{}');
+    expect(stored.claude.status).toMatchObject({ ok: true, version: '1.2.3', account: 'me' });
+    expect(typeof stored.claude.checkedAt).toBe('number');
+  });
+
+  it('restores valid cached status and ignores malformed entries', () => {
+    localStorage.setItem('mermark-ai-cli-health', JSON.stringify({
+      claude: {
+        status: { ok: true, version: '1.2.3', account: 'me', error: null, resolvedPath: '/bin/claude' },
+        checkedAt: 123,
+      },
+      codex: { status: { ok: 'yes' }, checkedAt: 'yesterday' },
+    }));
+
+    const restored = readPersistedCliHealth();
+    expect(restored.claude?.status.ok).toBe(true);
+    expect(restored.claude?.checkedAt).toBe(123);
+    expect(restored.codex).toBeUndefined();
   });
 });

--- a/src/__tests__/composables/useSettings.test.ts
+++ b/src/__tests__/composables/useSettings.test.ts
@@ -213,10 +213,20 @@ describe('useSettings', () => {
       // Note: singleton may have been mutated by other tests; verify shape rather
       // than exact values for fields that other tests can flip.
       expect(typeof settings.value.ai.enabled).toBe('boolean');
+      expect(typeof settings.value.ai.checkCliHealthOnStartup).toBe('boolean');
       expect(['claude', 'codex']).toContain(settings.value.ai.defaultCli);
       expect(typeof settings.value.ai.snapshotsKeep).toBe('number');
       expect(typeof settings.value.ai.hasSeenFirstRun).toBe('boolean');
       expect(['left', 'right']).toContain(settings.value.ai.panelSide);
+    });
+
+    it('enables CLI startup checks by default and allows disabling them', () => {
+      const { settings, setAiCheckCliHealthOnStartup } = useSettings();
+      setAiCheckCliHealthOnStartup(true);
+      expect(settings.value.ai.checkCliHealthOnStartup).toBe(true);
+      setAiCheckCliHealthOnStartup(false);
+      expect(settings.value.ai.checkCliHealthOnStartup).toBe(false);
+      setAiCheckCliHealthOnStartup(true);
     });
 
     it('clamps snapshotsKeep to a minimum of 1 on save', () => {

--- a/src/components/ai/AiSettingsTab.vue
+++ b/src/components/ai/AiSettingsTab.vue
@@ -13,6 +13,7 @@ const { t } = useI18n();
 const {
   settings,
   setAiEnabled,
+  setAiCheckCliHealthOnStartup,
   setAiDefaultCli,
   setAiDefaultModelClaude,
   setAiDefaultModelCodex,
@@ -287,6 +288,17 @@ async function copyAudit() {
 
     <section class="ai-settings-section">
       <h4>{{ t.aiSettingsCliHeading }}</h4>
+      <label class="ai-toggle-label ai-cli-startup-toggle">
+        <input
+          type="checkbox"
+          :checked="settings.ai.checkCliHealthOnStartup"
+          @change="setAiCheckCliHealthOnStartup(($event.target as HTMLInputElement).checked)"
+        />
+        <span>
+          <strong>{{ t.aiCheckCliHealthOnStartup }}</strong>
+          <small class="ai-helper ai-helper--toggle">{{ t.aiCheckCliHealthOnStartupHelper }}</small>
+        </span>
+      </label>
       <div v-for="cli in BINARY_CLIS" :key="cli" class="ai-cli-block">
         <div class="ai-cli-row">
           <div class="ai-cli-name-col">
@@ -619,6 +631,8 @@ async function copyAudit() {
 }
 .ai-toggle-label input[type="checkbox"] { margin-top: 2px; flex-shrink: 0; }
 .ai-toggle-label strong { font-weight: 600; }
+.ai-cli-startup-toggle { margin-bottom: 12px; }
+.ai-helper--toggle { padding-left: 0; }
 
 /* Inline label = label text + control on the same row */
 .ai-inline-label {

--- a/src/components/ai/AiStatusbarIndicator.vue
+++ b/src/components/ai/AiStatusbarIndicator.vue
@@ -5,13 +5,12 @@ import { useAiHealth } from '../../composables/useAiHealth';
 import { useSettings } from '../../composables/useSettings';
 
 const { settings } = useSettings();
-const { check, cache } = useAiHealth();
+const { checkCliOnStartup, cache } = useAiHealth();
 const { bypassEnabled } = useAi();
 
 onMounted(() => {
   if (settings.value.ai.enabled) {
-    check('claude').catch(() => {});
-    check('codex').catch(() => {});
+    checkCliOnStartup().catch(() => {});
   }
 });
 

--- a/src/composables/useAiHealth.ts
+++ b/src/composables/useAiHealth.ts
@@ -2,9 +2,67 @@ import { ref } from 'vue';
 import { aiCommands, type CliKind, type HealthStatus } from '../services/aiCommands';
 import { useSettings } from './useSettings';
 
-const cache = ref<Record<CliKind, HealthStatus | null>>({ claude: null, codex: null, ollama: null, openai: null });
-const lastCheckedAt = ref<Record<CliKind, number | null>>({ claude: null, codex: null, ollama: null, openai: null });
+const CLI_HEALTH_STORAGE_KEY = 'mermark-ai-cli-health';
+const CLI_KINDS = ['claude', 'codex'] as const;
+type BinaryCliKind = typeof CLI_KINDS[number];
+type PersistedCliHealth = Partial<Record<BinaryCliKind, { status: HealthStatus; checkedAt: number }>>;
+
+function isHealthStatus(value: unknown): value is HealthStatus {
+  if (!value || typeof value !== 'object') return false;
+  const status = value as Partial<HealthStatus>;
+  return typeof status.ok === 'boolean'
+    && (typeof status.version === 'string' || status.version === null)
+    && (typeof status.account === 'string' || status.account === null)
+    && (typeof status.error === 'string' || status.error === null)
+    && (typeof status.resolvedPath === 'string' || status.resolvedPath === null);
+}
+
+export function readPersistedCliHealth(): PersistedCliHealth {
+  try {
+    const raw = localStorage.getItem(CLI_HEALTH_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const result: PersistedCliHealth = {};
+    for (const cli of CLI_KINDS) {
+      const entry = parsed[cli] as { status?: unknown; checkedAt?: unknown } | undefined;
+      if (entry && isHealthStatus(entry.status) && typeof entry.checkedAt === 'number') {
+        result[cli] = { status: entry.status, checkedAt: entry.checkedAt };
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+const persisted = readPersistedCliHealth();
+const cache = ref<Record<CliKind, HealthStatus | null>>({
+  claude: persisted.claude?.status ?? null,
+  codex: persisted.codex?.status ?? null,
+  ollama: null,
+  openai: null,
+});
+const lastCheckedAt = ref<Record<CliKind, number | null>>({
+  claude: persisted.claude?.checkedAt ?? null,
+  codex: persisted.codex?.checkedAt ?? null,
+  ollama: null,
+  openai: null,
+});
 const loading = ref<Record<CliKind, boolean>>({ claude: false, codex: false, ollama: false, openai: false });
+
+function persistCliHealth() {
+  const stored: PersistedCliHealth = {};
+  for (const cli of CLI_KINDS) {
+    const status = cache.value[cli];
+    const checkedAt = lastCheckedAt.value[cli];
+    if (status && checkedAt !== null) stored[cli] = { status, checkedAt };
+  }
+  try {
+    localStorage.setItem(CLI_HEALTH_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // A health check should still succeed when browser storage is unavailable.
+  }
+}
 
 export function useAiHealth() {
   const {
@@ -65,6 +123,7 @@ export function useAiHealth() {
       const r = await aiCommands.healthCheck(cli, overrideFor(cli));
       cache.value[cli] = r;
       lastCheckedAt.value[cli] = Date.now();
+      if (cli === 'claude' || cli === 'codex') persistCliHealth();
       persistResolved(cli, r);
       return r;
     } catch (e) {
@@ -77,6 +136,7 @@ export function useAiHealth() {
       };
       cache.value[cli] = errStatus;
       lastCheckedAt.value[cli] = Date.now();
+      if (cli === 'claude' || cli === 'codex') persistCliHealth();
       return errStatus;
     } finally {
       loading.value[cli] = false;
@@ -92,10 +152,18 @@ export function useAiHealth() {
     ]);
   }
 
+  async function checkCliOnStartup() {
+    if (!settings.value.ai.checkCliHealthOnStartup) return;
+    await Promise.all([check('claude'), check('codex')]);
+  }
+
   function getCached(cli: CliKind) { return cache.value[cli]; }
-  function reset() {
+  function reset(clearPersisted = false) {
     cache.value = { claude: null, codex: null, ollama: null, openai: null };
     lastCheckedAt.value = { claude: null, codex: null, ollama: null, openai: null };
+    if (clearPersisted) {
+      try { localStorage.removeItem(CLI_HEALTH_STORAGE_KEY); } catch { /* ignore */ }
+    }
   }
 
   /**
@@ -109,7 +177,7 @@ export function useAiHealth() {
   }
 
   return {
-    check, checkAll, getCached, lastCheckedAt, reset, cache, loading,
+    check, checkAll, checkCliOnStartup, getCached, lastCheckedAt, reset, cache, loading,
     forgetResolvedCache,
   };
 }

--- a/src/composables/useSettings.ts
+++ b/src/composables/useSettings.ts
@@ -65,6 +65,8 @@ export const SIDEBAR_WIDTH_DEFAULT = 240;
 
 export interface AiSettings {
   enabled: boolean;
+  /** Probe Claude and Codex automatically when the application starts. */
+  checkCliHealthOnStartup: boolean;
   defaultCli: CliKind;
   defaultModelClaude: string;
   defaultModelCodex: string;
@@ -386,6 +388,7 @@ function getDefaultSettings(): AppSettings {
     },
     ai: {
       enabled: true,
+      checkCliHealthOnStartup: true,
       defaultCli: 'claude',
       defaultModelClaude: 'claude-opus-4-7',
       defaultModelCodex: 'gpt-5.5',
@@ -650,6 +653,7 @@ export function useSettings() {
   };
 
   const setAiEnabled = (v: boolean) => { settings.value.ai.enabled = v; };
+  const setAiCheckCliHealthOnStartup = (v: boolean) => { settings.value.ai.checkCliHealthOnStartup = v; };
   const setAiDefaultCli = (v: CliKind) => { settings.value.ai.defaultCli = v; };
   const setAiDefaultModelClaude = (v: string) => { settings.value.ai.defaultModelClaude = v; };
   const setAiDefaultModelCodex = (v: string) => { settings.value.ai.defaultModelCodex = v; };
@@ -714,6 +718,7 @@ export function useSettings() {
     setWorkspaceSortOverride,
     setFolderSortOverride,
     setAiEnabled,
+    setAiCheckCliHealthOnStartup,
     setAiDefaultCli,
     setAiDefaultModelClaude,
     setAiDefaultModelCodex,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -315,6 +315,8 @@ export interface Translations {
   // AI
   aiTabLabel: string;
   aiEnableLabel: string;
+  aiCheckCliHealthOnStartup: string;
+  aiCheckCliHealthOnStartupHelper: string;
   aiDefaultCli: string;
   aiPanelSide: string;
   aiPanelSideLeft: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -309,6 +309,8 @@ const en: Translations = {
   // AI
   aiTabLabel: 'AI',
   aiEnableLabel: 'Enable AI integration',
+  aiCheckCliHealthOnStartup: 'Check Claude and Codex at startup',
+  aiCheckCliHealthOnStartupHelper: 'When disabled, startup restores the last-known status. Opening the AI assistant or using Re-check refreshes it.',
   aiDefaultCli: 'Default CLI',
   aiPanelSide: 'Chat panel side',
   aiPanelSideLeft: 'Left',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -309,6 +309,8 @@ const pl: Translations = {
   // AI
   aiTabLabel: 'AI',
   aiEnableLabel: 'Włącz integrację AI',
+  aiCheckCliHealthOnStartup: 'Sprawdzaj Claude i Codex przy uruchamianiu',
+  aiCheckCliHealthOnStartupHelper: 'Po wyłączeniu aplikacja przywraca ostatni znany stan. Otwarcie asystenta AI lub opcja Sprawdź ponownie odświeża go.',
   aiDefaultCli: 'Domyślne CLI',
   aiPanelSide: 'Strona panelu czatu',
   aiPanelSideLeft: 'Lewo',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -309,6 +309,8 @@ const zhCN: Translations = {
   // AI
   aiTabLabel: 'AI',
   aiEnableLabel: '启用 AI 集成',
+  aiCheckCliHealthOnStartup: '启动时检查 Claude 和 Codex',
+  aiCheckCliHealthOnStartupHelper: '关闭后，启动时会恢复上次已知状态。打开 AI 助手或使用“重新检查”会刷新状态。',
   aiDefaultCli: '默认 CLI',
   aiPanelSide: '聊天面板位置',
   aiPanelSideLeft: '左侧',


### PR DESCRIPTION
## Summary

- Add one default-on setting for Claude and Codex launch-time health checks.
- Persist validated last-known CLI health results locally and restore them when launch checks are disabled.
- Preserve existing checks when the user opens the AI assistant/settings or selects Re-check.

## Motivation

The current status-bar mount runs the Claude and Codex health commands on every application launch. Some users prefer to avoid launching external CLI processes automatically, while still keeping both integrations and their normal on-demand health checks available.

## Behaviour

- Existing and new installations retain current behaviour because the preference defaults to enabled.
- When disabled, application launch does not invoke the Claude or Codex health commands.
- The last valid success or failure state, timestamp, version, account, error, and resolved path are restored from local storage.
- Malformed stored records are ignored.
- Opening the AI assistant or AI settings deliberately refreshes provider health using the existing flow.
- Manual Re-check remains unchanged.

## Test plan

- [x] Full frontend suite: 86 files / 1,147 tests.
- [x] Type-check with `vue-tsc --noEmit`.
- [x] Production Vite build.
- [x] Unit coverage for the default-on preference and disabled launch probes.
- [x] Unit coverage for status persistence, restoration, and malformed-record rejection.
- [x] Existing health-cache and manual-force-check tests remain passing.

🤖 Generated with Codex.
