### PR TITLE
Add math editing and improve Windows Codex CLI discovery

### DIFF
--- a/docs/issue-139-143-validation.md
+++ b/docs/issue-139-143-validation.md
@@ -1,0 +1,44 @@
+# Matematyka i wykrywanie Codex CLI
+
+## #139 — matematyka
+
+Interaktywne węzły TipTap oparto na [implementacji chinghssu/MerMarkEditorQ](https://github.com/chinghssu/MerMarkEditorQ/commit/b165dcf4fa5efbe04ac8d03adf0fc3d1f3f54393), udostępnionej na licencji MIT. Nie przenoszono przebudowy eksportu na wkhtmltopdf ani pozostałych zmian forka.
+
+Obsługiwane wejście: `$…$`, `$` z backtickami wewnątrz (wariant GitHub), `$$…$$`, `\(…\)`, `\[…\]`, bloki math/latex/tex z backtickami lub tyldami, środowiska equation/align/alignat/gather z opcjonalną gwiazdką oraz CD. Polecenia wewnątrz wzorów są ograniczone do możliwości KaTeX; nie jest to kompilator pełnego LaTeX ani TikZ.
+
+- Edytor wizualny: renderowanie, dwuklik lub Enter do edycji, zapis i anulowanie, przyciski wstawiania wzoru inline/blokowego.
+- Markdown: zachowanie delimitera i pełnego źródła; ochrona kodu, linków, HTML, escaped dolarów oraz zwykłych cen.
+- Długie dokumenty: podział podglądu nie przecina wzoru w połowie.
+- PDF: renderowane wzory i osadzone fonty WOFF2, bez CDN. Błędny wzór pozostaje bezpiecznym tekstem źródłowym.
+- Marp: wspólna normalizacja wariantów zapisu, natywny renderer matematyki Marp.
+- DOCX: zapis źródła LaTeX jako tekst, bez duplikowania warstw HTML/MathML. Natywne równania Worda nie są częścią tej zmiany.
+
+Kompletny dokument demonstracyjny: [math-showcase.md](math-showcase.md), 46 wzorów. PDF z testu aplikacji znajduje się lokalnie w `output/pdf/math-showcase.pdf`.
+
+## #143 — Codex CLI na Windows
+
+Ręczny wybór pliku już istniał. Sekcja jest teraz rozwinięta przy błędzie połączenia; pozwala wybrać plik, wkleić pełną ścieżkę albo wyczyścić wybór. Przyjmowane są ścieżki otoczone cudzysłowami i zmienne Windows, np. `%LOCALAPPDATA%`.
+
+Automatycznie przeszukiwane są:
+
+1. PATH, z obsługą rozszerzeń exe/cmd/bat.
+2. `%LOCALAPPDATA%\OpenAI\Codex\bin` i jego podkatalogi wersji.
+3. `%APPDATA%\npm`.
+4. `%USERPROFILE%\.local\bin`, `scoop\shims`, `.cargo\bin`, `.volta\bin`, `.bun\bin`.
+
+Nazwy podkatalogów wersji są hashami, więc nie traktujemy ich jako numerów wersji. Kandydaci z tych podkatalogów są sprawdzani od najnowszego czasu modyfikacji. Sprawdzenie wymaga odpowiedzi `codex-cli …` na `--version`; plik launchera z WindowsApps jest odrzucany. Proces sprawdzający ma limit czasu i jest kończony po jego przekroczeniu.
+
+„Re-check” ignoruje zapamiętaną automatyczną ścieżkę, ale respektuje wybór ręczny. Nieistniejąca ręcznie wybrana ścieżka zgłasza błąd zamiast uruchamiać inną instalację. Usunięty automatycznie zapamiętany pakiet powoduje ponowne wyszukanie podczas testu zdrowia. Zweryfikowana ścieżka jest również przekazywana przy uruchamianiu rozmowy.
+
+Przykład ścieżki do CLI dostarczanego z aplikacją desktopową: `%LOCALAPPDATA%\OpenAI\Codex\bin\<wersja>\codex.exe`. Nie wybieraj launchera `WindowsApps\OpenAI.Codex_…\app\Codex.exe`.
+
+## Weryfikacja
+
+- `pnpm exec vitest run`: pełny zestaw testów frontendu.
+- `cargo test --lib ai:: --manifest-path src-tauri/Cargo.toml`: testy części AI, w tym wykrywanie plików bez PATH, ręczne ścieżki i odrzucenie launchera.
+- `pnpm build`: kontrola typów i produkcyjny build.
+- `pnpm exec playwright test tests/e2e/math.test.ts tests/e2e/atomic-save.test.ts tests/e2e/tab-close-code-view.test.ts tests/e2e/cursor-marker-images.test.ts`: testy przeglądarkowe z emulacją IPC Tauri.
+
+Test matematyki otwiera dokument, renderuje wszystkie przykłady, edytuje i zapisuje wzór, przełącza widoki, przeładowuje aplikację, generuje PDF offline i sprawdza slajdy Marp. Testuje też poprawianie błędnego wzoru i przyciski wstawiania. Testy konwertera przechodzą przez rzeczywisty schemat TipTap i porównują źródło po zapisie. PDF został dodatkowo wyrenderowany do obrazów stron i obejrzany.
+
+Nie wykonywano płatnego zapytania do modelu ani nie zmieniano logowania Codex. Testy przeglądarkowe nie zastępują testu całego pakietu instalacyjnego Tauri na komputerze autora zgłoszenia.

--- a/docs/math-showcase.md
+++ b/docs/math-showcase.md
@@ -1,0 +1,195 @@
+# Matematyka w MerMark Editor
+
+Dokument demonstracyjny i zestaw przykładów do sprawdzenia widoku wizualnego, zapisu Markdown, slajdów Marp oraz wydruku PDF. Wzór można edytować dwuklikiem lub klawiszem Enter po ustawieniu na nim fokusu. Enter zapisuje wzór w tekście, Ctrl+Enter zapisuje blok, Escape anuluje edycję. Przyciski 𝑥² i ∑ w pasku narzędzi wstawiają nowe wzory.
+
+## 1. Warianty zapisu
+
+W tekście, dolary: $E=mc^2$.
+
+W tekście, nawiasy LaTeX: \(U=RI\).
+
+Wariant GitHub z backtickami: $`a^2+b^2=c^2`$.
+
+Dolary blokowe w jednej linii:
+
+$$P=UI$$
+
+Dolary blokowe w wielu liniach:
+
+$$
+Z=R+j\omega L
+$$
+
+Nawiasy kwadratowe LaTeX:
+
+\[
+Y=\frac{1}{Z}
+\]
+
+Blok `math`:
+
+```math
+f_0=\frac{1}{2\pi\sqrt{LC}}
+```
+
+Blok `latex` z tyldami:
+
+~~~latex
+\omega_0=2\pi f_0
+~~~
+
+Blok `tex` z czterema backtickami:
+
+````tex
+Q=\frac{\omega_0 L}{R}
+````
+
+Środowisko `equation`, bez dodatkowych dolarów:
+
+\begin{equation}
+\nabla\cdot\mathbf{D}=\rho
+\end{equation}
+
+Środowisko `align*`:
+
+\begin{align*}
+U_R &= RI \\
+U_L &= j\omega LI \\
+U_C &= \frac{I}{j\omega C}
+\end{align*}
+
+Środowisko `gather`:
+
+\begin{gather}
+a^2+b^2=c^2 \\
+e^{j\pi}+1=0
+\end{gather}
+
+Środowisko `alignat`:
+
+\begin{alignat}{2}
+10&x+&3&y=2\\
+3&x+&13&y=4
+\end{alignat}
+
+## 2. Ułamki, indeksy i symbole
+
+Indeksy: $x_i^2+x_{i+1}^2$, pierwiastki: $\sqrt{x}+\sqrt[3]{y}$.
+
+$$
+\frac{1}{1+\frac{1}{sRC}}=\frac{sRC}{1+sRC}
+$$
+
+Litery greckie i operatory: $\alpha+\beta=\gamma$, $\Omega\neq\omega$, $a\leq b$, $x\in\mathbb{R}$.
+
+$$
+\left|\frac{U_{out}}{U_{in}}\right|=\frac{1}{\sqrt{1+(\omega RC)^2}}
+$$
+
+Akcenty i wektory: $\vec{E}$, $\hat{x}$, $\overline{z}$, $\dot{x}$, $\ddot{x}$.
+
+## 3. Całki, sumy, granice i pochodne
+
+$$
+\int_0^{\infty}e^{-at}\,dt=\frac{1}{a},\qquad a>0
+$$
+
+$$
+\sum_{n=0}^{\infty}r^n=\frac{1}{1-r},\qquad |r|<1
+$$
+
+$$
+\lim_{h\to0}\frac{f(x+h)-f(x)}{h}=f'(x)
+$$
+
+$$
+\frac{\partial^2 u}{\partial t^2}=c^2\nabla^2u
+$$
+
+## 4. Macierze i układy
+
+$$
+\mathbf{A}=\begin{bmatrix}R_1+R_2&-R_2\\-R_2&R_2+R_3\end{bmatrix}
+$$
+
+$$
+\begin{pmatrix}I_1\\I_2\end{pmatrix}=\mathbf{A}^{-1}\begin{pmatrix}U_1\\U_2\end{pmatrix}
+$$
+
+$$
+\det A=\begin{vmatrix}a&b\\c&d\end{vmatrix}=ad-bc
+$$
+
+$$
+u(t)=\begin{cases}0&t<0\\1&t\geq0\end{cases}
+$$
+
+$$
+\begin{aligned}
+\nabla\times\mathbf{E}&=-\frac{\partial\mathbf{B}}{\partial t}\\
+\nabla\times\mathbf{H}&=\mathbf{J}+\frac{\partial\mathbf{D}}{\partial t}
+\end{aligned}
+$$
+
+## 5. Opisy, kolor i numer wzoru
+
+$$
+\underbrace{RI}_{\text{rezystor}}+\underbrace{L\frac{dI}{dt}}_{\text{cewka}}=U(t)\tag{1}
+$$
+
+$$
+\color{teal}{P}=\color{blue}{U}\cdot\color{purple}{I}
+$$
+
+$$
+\boxed{H(s)=\frac{1}{1+sRC}}
+$$
+
+Makra są lokalne dla jednego wzoru:
+
+$$
+\def\vect#1{\mathbf{#1}}\vect{E}\cdot\vect{D}
+$$
+
+## 6. Wzory w elementach dokumentu
+
+- Rezystor: $Z_R=R$.
+- Cewka: $Z_L=j\omega L$.
+- Kondensator: $Z_C=\frac{1}{j\omega C}$.
+
+> Prawo Ohma: $U=RI$.
+
+| Wielkość | Wzór |
+| --- | --- |
+| Moc czynna | $P=UI\cos\varphi$ |
+| Moc bierna | $Q=UI\sin\varphi$ |
+| Moc pozorna | $S=UI$ |
+
+## 7. Przykłady, które pozostają tekstem
+
+Ceny $5 i $10 nie są wzorami. Escapowane dolary: \$x\$.
+
+Kod inline: `$x^2$` oraz `\(x\)`.
+
+```javascript
+const literal = "$x^2$";
+// $$ to również zwykły kod
+```
+
+~~~text
+\[To jest przykład kodu, nie wzór\]
+~~~
+
+    $to_jest_kod$
+
+## 8. Zakres i ograniczenia
+
+Renderowanie obejmuje polecenia wspierane przez KaTeX, m.in. środowiska matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix, cases, aligned, gathered i array wewnątrz wzorów. Środowiska equation, align, alignat, gather (także wersje z gwiazdką) oraz CD mogą występować bez dolarów. Renderer numeruje środowiska bez gwiazdki. Dla stałych numerów pomiędzy widokami użyj `\tag{...}`; odwołania `\label`/`\ref` nie są obsługiwane. Nie jest to kompilator pełnych dokumentów LaTeX ani TikZ.
+
+Błędne wyrażenie jest wyświetlane jako bezpieczny tekst źródłowy i pozostaje edytowalne. Polecenia ładujące zewnętrzne zasoby są zablokowane. Fonty PDF są dołączone lokalnie. DOCX zachowuje źródło LaTeX jako tekst; nie tworzy natywnych równań Worda.
+
+W slajdach Marp alternatywne delimitery są normalizowane do zapisu dolarowego i renderowane przez silnik matematyczny Marp. Dokument Markdown zachowuje oryginalne delimitery i treść wzoru.
+
+## Pochodzenie
+
+Węzły edytora zaadaptowano z chinghssu/MerMarkEditorQ, commit b165dcf4fa5efbe04ac8d03adf0fc3d1f3f54393, licencja MIT. Parser, zachowanie źródła, integracja z Marp i fonty wydruku zostały dostosowane do bieżącego MerMark Editor.

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "diff": "^8.0.3",
     "docx": "^9.6.1",
     "github-slugger": "^2.0.0",
+    "katex": "^0.18.4",
     "lowlight": "^3.3.0",
     "mermaid": "^11.15.0",
     "vue": "^3.5.13"
@@ -83,6 +84,7 @@
     "@playwright/test": "^1.58.2",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/cli": "^2.5.0",
+    "@types/katex": "^0.16.8",
     "@types/node": "^25.8.0",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vue/test-utils": "^2.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      katex:
+        specifier: ^0.18.4
+        version: 0.18.4
       lowlight:
         specifier: ^3.3.0
         version: 3.3.0
@@ -157,6 +160,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2.5.0
         version: 2.9.6
+      '@types/katex':
+        specifier: ^0.16.8
+        version: 0.16.8
       '@types/node':
         specifier: ^25.8.0
         version: 25.8.0
@@ -1305,6 +1311,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
@@ -1927,12 +1936,12 @@ packages:
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
-  katex@0.16.27:
-    resolution: {integrity: sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==}
-    hasBin: true
-
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  katex@0.18.4:
+    resolution: {integrity: sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==}
     hasBin: true
 
   khroma@2.1.0:
@@ -3516,6 +3525,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/katex@0.16.8': {}
+
   '@types/linkify-it@5.0.0': {}
 
   '@types/markdown-it@14.1.2':
@@ -4203,11 +4214,11 @@ snapshots:
       readable-stream: 2.3.8
       setimmediate: 1.0.5
 
-  katex@0.16.27:
+  katex@0.16.47:
     dependencies:
       commander: 8.3.0
 
-  katex@0.16.47:
+  katex@0.18.4:
     dependencies:
       commander: 8.3.0
 
@@ -4285,7 +4296,7 @@ snapshots:
       dayjs: 1.11.19
       dompurify: 3.4.8
       es-toolkit: 1.47.0
-      katex: 0.16.27
+      katex: 0.16.47
       khroma: 2.1.0
       marked: 16.4.2
       roughjs: 4.6.6

--- a/src-tauri/src/ai/cli.rs
+++ b/src-tauri/src/ai/cli.rs
@@ -19,12 +19,11 @@
 
 use std::ffi::OsString;
 use std::path::Path;
-#[cfg(unix)]
 use std::path::PathBuf;
 
 /// Resolve `name` with optional explicit override path. The override always
-/// wins when it points to an existing file — even on Unix where executable
-/// bit checks would normally apply, since the user explicitly picked it.
+/// wins, including when missing: a manual selection must fail explicitly
+/// rather than silently running a different installation.
 pub fn resolve_with_override(name: &str, override_path: Option<&str>) -> OsString {
     resolve_with_override_info(name, override_path).0
 }
@@ -37,36 +36,142 @@ pub fn resolve_with_override_info(
     override_path: Option<&str>,
 ) -> (OsString, Option<String>) {
     if let Some(p) = override_path {
-        let trimmed = p.trim();
+        let normalized = normalize_override(p);
+        let trimmed = normalized.as_str();
         if !trimmed.is_empty() {
             let candidate = Path::new(trimmed);
-            if candidate.is_file() {
-                let os = candidate.as_os_str().to_os_string();
-                let display = candidate.to_string_lossy().into_owned();
-                return (os, Some(display));
-            }
+            let os = candidate.as_os_str().to_os_string();
+            let display = candidate.to_string_lossy().into_owned();
+            return (os, Some(display));
         }
     }
     resolve_info(name)
 }
 
 pub fn resolve_info(name: &str) -> (OsString, Option<String>) {
-    if let Ok(p) = which::which(name) {
+    if let Some(p) = candidates(name).into_iter().next() {
         let display = p.to_string_lossy().into_owned();
         return (p.into_os_string(), Some(display));
     }
+    (OsString::from(name), None)
+}
+
+/// Explicit paths never silently fall back to another installation.
+pub fn normalize_override(raw: &str) -> String {
+    let value = raw.trim().trim_matches('"');
+    #[cfg(windows)]
+    {
+        let mut out = String::new();
+        let mut rest = value;
+        while let Some(start) = rest.find('%') {
+            out.push_str(&rest[..start]);
+            rest = &rest[start..];
+            if let Some(end) = rest[1..].find('%') {
+                let end = end + 1;
+                let key = &rest[1..end];
+                out.push_str(&std::env::var(key).unwrap_or_else(|_| rest[..=end].to_string()));
+                rest = &rest[end + 1..];
+            } else { break; }
+        }
+        out.push_str(rest);
+        return out;
+    }
+    #[cfg(not(windows))]
+    value.to_string()
+}
+
+pub fn is_desktop_launcher(path: &Path) -> bool {
+    let p = path.to_string_lossy().replace('\\', "/").to_lowercase();
+    (p.contains("/windowsapps/openai.codex_") && p.ends_with("/app/codex.exe"))
+        || p.ends_with("/microsoft/windowsapps/codex.exe")
+}
+
+pub fn candidates(name: &str) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    if let Ok(paths) = which::which_all(name) {
+        result.extend(paths.filter(|p| name != "codex" || !is_desktop_launcher(p)));
+    }
+    #[cfg(windows)]
+    result.extend(windows_candidates(name,
+        std::env::var_os("LOCALAPPDATA").map(PathBuf::from).as_deref(),
+        std::env::var_os("APPDATA").map(PathBuf::from).as_deref(),
+        std::env::var_os("USERPROFILE").map(PathBuf::from).as_deref()));
     #[cfg(unix)]
     {
         if let Some(p) = resolve_unix_fallback(name) {
-            let display = p.to_string_lossy().into_owned();
-            return (p.into_os_string(), Some(display));
+            result.push(p);
         }
-        if let Some(p) = resolve_via_login_shell(name) {
-            let display = p.to_string_lossy().into_owned();
-            return (p.into_os_string(), Some(display));
+        if result.is_empty() {
+            if let Some(p) = resolve_via_login_shell(name) { result.push(p); }
         }
     }
-    (OsString::from(name), None)
+    let mut seen = std::collections::HashSet::new();
+    result.retain(|p| seen.insert(p.clone()));
+    result
+}
+
+#[cfg(any(windows, test))]
+fn windows_candidates(name: &str, local: Option<&Path>, roaming: Option<&Path>, user: Option<&Path>) -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if name == "codex" {
+        if let Some(local) = local {
+            let bin = local.join("OpenAI/Codex/bin");
+            dirs.push(bin.clone());
+            // Bundle directory names are hashes, not sortable versions. Prefer
+            // recently updated installations, but health-check every candidate.
+            let mut versions: Vec<_> = std::fs::read_dir(&bin).into_iter().flatten()
+                .flatten().filter(|e| e.path().is_dir()).collect();
+            versions.sort_by_key(|e| std::cmp::Reverse(e.metadata().and_then(|m| m.modified()).ok()));
+            dirs.extend(versions.into_iter().map(|e| e.path()));
+        }
+    }
+    if let Some(roaming) = roaming { dirs.push(roaming.join("npm")); }
+    if let Some(user) = user {
+        dirs.extend([user.join(".local/bin"), user.join("scoop/shims"), user.join(".cargo/bin"), user.join(".volta/bin"), user.join(".bun/bin")]);
+    }
+    dirs.into_iter().flat_map(|dir| ["exe", "cmd", "bat"].map(|ext| dir.join(format!("{name}.{ext}"))))
+        .filter(|p| p.is_file()).collect()
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    use super::*;
+
+    #[test]
+    fn detects_bundled_versions_and_npm_without_path() {
+        let root = std::env::temp_dir().join(format!("mermark-cli-test-{}", uuid::Uuid::new_v4()));
+        let local = root.join("Local");
+        let roaming = root.join("Roaming");
+        let version = local.join("OpenAI/Codex/bin/version-hash/codex.exe");
+        let npm = roaming.join("npm/codex.cmd");
+        for path in [&version, &npm] {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, "test fixture").unwrap();
+        }
+        let paths = windows_candidates("codex", Some(&local), Some(&roaming), None);
+        assert_eq!(paths, vec![version, npm]);
+        assert!(windows_candidates("claude", Some(&local), None, None).is_empty());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn identifies_desktop_launcher_but_allows_cli_bundle() {
+        assert!(is_desktop_launcher(Path::new(r"C:\Program Files\WindowsApps\OpenAI.Codex_26\app\Codex.exe")));
+        assert!(!is_desktop_launcher(Path::new(r"C:\Users\User\AppData\Local\OpenAI\Codex\bin\hash\codex.exe")));
+    }
+
+    #[test]
+    fn missing_manual_path_is_not_replaced_with_path_lookup() {
+        let (_, actual) = resolve_with_override_info("codex", Some("  \"missing/custom/codex.exe\"  "));
+        assert_eq!(actual.as_deref(), Some("missing/custom/codex.exe"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn expands_windows_environment_variables_without_shell() {
+        let expected = format!("{}\\OpenAI\\Codex", std::env::var("LOCALAPPDATA").unwrap());
+        assert_eq!(normalize_override(r"%LOCALAPPDATA%\OpenAI\Codex"), expected);
+    }
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/ai/health/codex.rs
+++ b/src-tauri/src/ai/health/codex.rs
@@ -22,33 +22,57 @@ use crate::ai::cli;
 const CMD: &str = "codex";
 
 pub async fn probe(override_path: Option<&str>) -> HealthStatus {
-    let resolved_path = cli::resolve_with_override_info(CMD, override_path).1;
-    let version = match run_capture(override_path, &["--version"], 5).await {
-        Ok((true, out, _)) => Some(out.trim().to_string()),
-        _ => {
-            return HealthStatus {
-                ok: false,
-                version: None,
-                account: None,
-                error: Some("Binary not found".into()),
-                resolved_path,
-            }
+    let manual = override_path.map(cli::normalize_override).filter(|s| !s.is_empty());
+    let paths = if let Some(path) = manual { vec![std::path::PathBuf::from(path)] } else { cli::candidates(CMD) };
+    let mut failure = HealthStatus { ok: false, version: None, account: None,
+        error: Some("Codex CLI not found. Select its .exe or .cmd file manually.".into()), resolved_path: None };
+    for path in paths.into_iter().take(12) {
+        let path = path.to_string_lossy().into_owned();
+        failure.resolved_path = Some(path.clone());
+        if cli::is_desktop_launcher(std::path::Path::new(&path)) {
+            failure.error = Some("Selected file is the desktop app launcher. Choose Codex CLI from OpenAI/Codex/bin instead.".into());
+            continue;
         }
-    };
-    let auth = run_capture(override_path, &["login", "status"], 10).await;
+        if !std::path::Path::new(&path).is_file() {
+            failure.error = Some("Selected CLI file does not exist. Check the custom binary path.".into());
+            continue;
+        }
+        let version = match run_capture(Some(&path), &["--version"], 5).await {
+            Ok((true, out, err)) => {
+                match cli_version(&out).or_else(|| cli_version(&err)) {
+                    Some(version) => version,
+                    None => { failure.error = Some("Selected program is not Codex CLI (--version did not report codex-cli).".into()); continue; }
+                }
+            }
+            Ok((false, _, err)) => { failure.error = Some(format!("CLI version check failed: {}", err.trim())); continue; }
+            Err(error) => { failure.error = Some(format!("Cannot run Codex CLI: {error}")); continue; }
+        };
+        return probe_auth(&path, version).await;
+    }
+    failure
+}
+
+fn cli_version(output: &str) -> Option<String> {
+    output.lines().map(str::trim).find(|line| line.starts_with("codex-cli ") && line[10..].starts_with(|c: char| c.is_ascii_digit())).map(str::to_string)
+}
+
+async fn probe_auth(path: &str, version: String) -> HealthStatus {
+    let resolved_path = Some(path.to_string());
+    let version = Some(version);
+    let auth = run_capture(Some(path), &["login", "status"], 10).await;
     match auth {
-        Ok((true, out, _)) => HealthStatus {
+        Ok((true, out, err)) => HealthStatus {
             ok: true,
             version,
-            account: parse_account(&out),
+            account: parse_account(&out).or_else(|| parse_account(&err)),
             error: None,
             resolved_path,
         },
-        Ok((false, _, err)) => HealthStatus {
+        Ok((false, out, err)) => HealthStatus {
             ok: false,
             version,
             account: None,
-            error: Some(if err.is_empty() { "Authentication required".into() } else { err }),
+            error: Some(format!("Authentication required: {}", if err.is_empty() { out } else { err })),
             resolved_path,
         },
         Err(e) => HealthStatus {
@@ -87,6 +111,7 @@ async fn run_capture(
     let fut = async {
         let mut cmd = Command::new(cli::resolve_with_override(CMD, override_path));
         cmd.args(args)
+            .kill_on_drop(true)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         cli::hide_console(&mut cmd);
@@ -108,6 +133,27 @@ async fn run_capture(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn accepts_cli_version_but_not_desktop_version() {
+        assert_eq!(cli_version("codex-cli 0.151.0-alpha.7.2\n"), Some("codex-cli 0.151.0-alpha.7.2".into()));
+        assert_eq!(cli_version("26.825.6671.0"), None);
+        assert_eq!(cli_version("codex-cli "), None);
+    }
+
+    #[tokio::test]
+    async fn reports_missing_custom_path_without_fallback() {
+        let status = probe(Some("missing/custom/codex.exe")).await;
+        assert!(!status.ok);
+        assert!(status.error.unwrap().contains("does not exist"));
+    }
+
+    #[tokio::test]
+    async fn rejects_desktop_launcher_without_starting_it() {
+        let status = probe(Some(r"C:\Program Files\WindowsApps\OpenAI.Codex_26\app\Codex.exe")).await;
+        assert!(!status.ok);
+        assert!(status.error.unwrap().contains("desktop app launcher"));
+    }
 
     #[test]
     fn parse_account_extracts_value_after_colon() {

--- a/src-tauri/src/ai/process/codex.rs
+++ b/src-tauri/src/ai/process/codex.rs
@@ -37,7 +37,11 @@ const CMD: &str = "codex";
 /// arguments are invalid"); (b) stdin is the documented escape hatch for
 /// codex when "instructions are read from stdin".
 pub async fn spawn(req: &AiSendRequest) -> Result<Child, String> {
-    let mut cmd = Command::new(cli::resolve_with_override(CMD, req.cli_path.as_deref()));
+    let binary = cli::resolve_with_override(CMD, req.cli_path.as_deref());
+    if cli::is_desktop_launcher(std::path::Path::new(&binary)) {
+        return Err("Choose Codex CLI, not the desktop app launcher.".into());
+    }
+    let mut cmd = Command::new(binary);
 
     // codex `exec resume` does not surface `-i <FILE>`. If the user attached
     // images to this turn, we MUST take the new-session path so the images

--- a/src/__tests__/composables/useAiHealth.test.ts
+++ b/src/__tests__/composables/useAiHealth.test.ts
@@ -15,6 +15,9 @@ describe('useAiHealth', () => {
     vi.clearAllMocks();
     useAiHealth().reset(true);
     useSettings().setAiCheckCliHealthOnStartup(true);
+    useSettings().setAiCliPathCodex('');
+    useSettings().setAiCliPathClaude('');
+    useAiHealth().forgetResolvedCache();
   });
 
   it('caches the first result and does not re-call without force', async () => {
@@ -33,6 +36,27 @@ describe('useAiHealth', () => {
     await check('claude');
     await check('claude', true);
     expect(aiCommands.healthCheck).toHaveBeenCalledTimes(2);
+  });
+
+  it('recheck discovers again but preserves an explicit manual path', async () => {
+    vi.mocked(aiCommands.healthCheck).mockResolvedValue({ ok: false, version: null, account: null, error: 'missing', resolvedPath: null });
+    useSettings().setAiCliResolvedPathCodex('old/bundle/codex.exe');
+    await useAiHealth().check('codex', true);
+    expect(aiCommands.healthCheck).toHaveBeenLastCalledWith('codex', null);
+    useSettings().setAiCliPathCodex('chosen/codex.exe');
+    await useAiHealth().check('codex', true);
+    expect(aiCommands.healthCheck).toHaveBeenLastCalledWith('codex', 'chosen/codex.exe');
+  });
+
+  it('rediscovers a removed cached bundle automatically', async () => {
+    useSettings().setAiCliResolvedPathCodex('old/bundle/codex.exe');
+    vi.mocked(aiCommands.healthCheck)
+      .mockResolvedValueOnce({ ok: false, version: null, account: null, error: 'missing', resolvedPath: 'old/bundle/codex.exe' })
+      .mockResolvedValueOnce({ ok: true, version: 'codex-cli 1', account: 'me', error: null, resolvedPath: 'new/bundle/codex.exe' });
+    await useAiHealth().check('codex');
+    expect(aiCommands.healthCheck).toHaveBeenNthCalledWith(1, 'codex', 'old/bundle/codex.exe');
+    expect(aiCommands.healthCheck).toHaveBeenNthCalledWith(2, 'codex', null);
+    expect(useSettings().settings.value.ai.cliResolvedPathCodex).toBe('new/bundle/codex.exe');
   });
 
   it('reset initializes an ollama cache slot', () => {

--- a/src/__tests__/utils/math.test.ts
+++ b/src/__tests__/utils/math.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+import { KatexBlockExtension, KatexInlineExtension } from '../../extensions/KatexExtension';
+import { findMath, mathMarkdown, renderMath, normalizeMathForMarp } from '../../utils/math';
+import { htmlToMarkdown, markdownToHtml } from '../../utils/markdown-converter';
+import { serializeEditorContent } from '../../utils/documentSerializer';
+import { splitMarkdownForLazyPreview } from '../../utils/lazy-markdown';
+import { buildPrintDocument, PDF_SETTINGS_DEFAULTS } from '../../composables/usePdfExport';
+import { readFileSync } from 'node:fs';
+
+const variants = [
+  '$x_1^2$', '$$x_1^2$$', '$$\nx_1^2\n$$', String.raw`\(x_1^2\)`, String.raw`\[x_1^2\]`,
+  '```math\nx_1^2\n```', '~~~latex\nx_1^2\n~~~', '````tex\nx_1^2\n````',
+  String.raw`\begin{equation}x_1^2\end{equation}`,
+  String.raw`\begin{align*}a&=b\\c&=d\end{align*}`,
+  '$`x_1^2`$',
+  '$$\na+b\n\n\n+c\n$$',
+];
+
+describe('math source and editor round trips', () => {
+  it.each(variants)('preserves %s through the actual TipTap schema', source => {
+    const before = findMath(source);
+    expect(before).toHaveLength(1);
+    const editor = new Editor({ extensions: [StarterKit, KatexBlockExtension, KatexInlineExtension], content: markdownToHtml(source) });
+    const saved = htmlToMarkdown(editor.getHTML());
+    expect(saved.trim()).toBe(source);
+    expect(findMath(saved).map(m => m.formula)).toEqual(before.map(m => m.formula));
+    editor.destroy();
+  });
+
+  it.each([
+    String.raw`Escaped \$x\$ and \$$y\$$`,
+    'Costs $5 and $10 today.',
+    '```js\nconst x = "$a$";\n```',
+    '~~~text\n$$x$$\n~~~',
+    '`$a$` and `` $b$ ``',
+    '    $a$\n    $$b$$',
+    '[link](https://example.com/$a$)',
+    '<img alt="$a$" src="x">',
+    '<p>Raw HTML $a$</p>',
+    '<pre><code>$a$</code></pre>',
+    '<details><details>$a$</details>$b$</details>',
+  ])('does not interpret code, escaped dollars or currency: %s', source => {
+    expect(findMath(source)).toEqual([]);
+    expect(markdownToHtml(source)).not.toContain('data-type="katex-');
+  });
+
+  it('handles inline math within lists, tables, emphasis and links', () => {
+    const source = '- Value $x_1$\n\n| X | Y |\n|---|---|\n| $a$ | $b$ |\n\n**$c$** and [$d$](https://example.com)';
+    const editor = new Editor({ extensions: [StarterKit, KatexBlockExtension, KatexInlineExtension], content: markdownToHtml(source) });
+    expect(findMath(htmlToMarkdown(editor.getHTML())).map(m => m.formula)).toEqual(['x_1', 'a', 'b', 'c', 'd']);
+    editor.destroy();
+  });
+
+  it('does not flatten nested KaTeX HTML on serialization', () => {
+    const root = document.createElement('div');
+    root.innerHTML = markdownToHtml('Before $a$ after\n\n$$b$$');
+    const printed = serializeEditorContent(root);
+    const saved = htmlToMarkdown(printed);
+    expect(findMath(saved).map(m => m.formula)).toEqual(['a', 'b']);
+    expect(saved).not.toContain('katex');
+  });
+
+  it('uses new source after changing formula or display mode', () => {
+    expect(mathMarkdown('y', '$x$', false)).toBe('$y$');
+    expect(mathMarkdown('x', '$x$', true)).toBe('$$\nx\n$$');
+  });
+
+  it('keeps a large multiline display equation inside one lazy chunk', () => {
+    const formula = '$$\n' + ('a+\n\n'.repeat(12000)) + 'b\n$$';
+    const source = '# Start\n\n' + formula + '\n\nEnd';
+    const chunks = splitMarkdownForLazyPreview(source);
+    expect(chunks.map(c => c.markdown).join('\n')).toBe(source);
+    expect(chunks.some(c => c.markdown.includes(formula))).toBe(true);
+  });
+});
+
+describe('rendering and exports', () => {
+  it('renders all examples in the demonstration document', () => {
+    const source = readFileSync('docs/math-showcase.md', 'utf8');
+    const math = findMath(source);
+    expect(math.length).toBeGreaterThan(25);
+    for (const m of math) expect(renderMath(m.formula, m.display).error, m.source).toBeNull();
+    const saved = htmlToMarkdown(markdownToHtml(source));
+    expect(findMath(saved).map(m => m.source)).toEqual(math.map(m => m.source));
+  });
+
+  it('shows malformed input as escaped, recoverable source', () => {
+    const result = renderMath(String.raw`\bad{<img src=x onerror="alert(1)">}`, true);
+    expect(result.error).not.toBeNull();
+    const root = new DOMParser().parseFromString(result.html, 'text/html');
+    expect(root.querySelector('img')).toBeNull();
+    expect(root.body.textContent).toContain('<img');
+  });
+
+  it('does not allow external images or unsafe URLs in formulas', () => {
+    expect(renderMath(String.raw`\includegraphics{https://example.com/tracker}`, false).html).not.toContain('<img');
+    expect(renderMath(String.raw`\href{javascript:alert(1)}{x}`, false).html).not.toContain('href="javascript:');
+  });
+
+  it('prints real math with embedded fonts and without editor controls', () => {
+    const html = buildPrintDocument(markdownToHtml('$x$\n\n$$x^2$$'), PDF_SETTINGS_DEFAULTS, '');
+    expect(html).toContain('class="katex"');
+    expect(html).toContain('data:font/woff2;base64,');
+    expect(html).not.toContain('url(fonts/');
+    expect(html).not.toContain('katex-actions');
+  });
+
+  it('normalizes alternative syntaxes for Marp without changing code samples', () => {
+    const source = String.raw`\(x\)` + '\n\n```math\ny\n```\n\n`$z$`';
+    expect(normalizeMathForMarp(source)).toContain('$x$');
+    expect(normalizeMathForMarp(source)).toContain('$$\ny\n$$');
+    expect(normalizeMathForMarp(source)).toContain('`$z$`');
+  });
+});

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -89,6 +89,8 @@ let imageResolutionInProgress = false;
 // HTML snapshot from last file open/save — used to detect real changes (e.g. after undo).
 let lastSavedHtml = '';
 import { MermaidExtension } from "../extensions/MermaidExtension";
+import { KatexBlockExtension, KatexInlineExtension } from "../extensions/KatexExtension";
+import 'katex/dist/katex.min.css';
 import { PageBreakExtension } from "../extensions/PageBreakExtension";
 import { MarpFrontmatterExtension } from "../extensions/MarpFrontmatterExtension";
 import { MarpDirectiveExtension } from "../extensions/MarpDirectiveExtension";
@@ -512,6 +514,8 @@ const editor = useEditor({
       placeholder: t.value.placeholder,
     }),
     MermaidExtension,
+    KatexBlockExtension,
+    KatexInlineExtension,
     PageBreakExtension,
     MarpFrontmatterExtension,
     MarpDirectiveExtension,

--- a/src/components/KatexNode.vue
+++ b/src/components/KatexNode.vue
@@ -1,0 +1,304 @@
+<script setup lang="ts">
+import { NodeViewWrapper } from "@tiptap/vue-3";
+import { ref, watch, onMounted, computed, nextTick } from "vue";
+import { renderMath, findMath } from '../utils/math';
+import { useI18n } from '../i18n';
+
+// Adapted from chinghssu/MerMarkEditorQ, commit b165dcf4 (MIT).
+const { t } = useI18n();
+
+const props = defineProps<{
+  node: {
+    type: { name: string };
+    attrs: { formula: string; source?: string };
+  };
+  updateAttributes: (attrs: Record<string, unknown>) => void;
+  deleteNode: () => void;
+  selected: boolean;
+}>();
+
+const isBlock = computed(() => props.node.type.name === "katexBlock");
+const encodedFormula = computed(() => encodeURIComponent(props.node.attrs.formula));
+
+const isEditing = ref(false);
+const editFormula = ref(props.node.attrs.formula);
+const renderedHtml = ref("");
+const error = ref<string | null>(null);
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+
+const render = () => {
+  const result = renderMath(props.node.attrs.formula, isBlock.value);
+  renderedHtml.value = result.html;
+  error.value = result.error;
+};
+
+const startEdit = () => {
+  editFormula.value = props.node.attrs.formula;
+  isEditing.value = true;
+  nextTick(() => textareaRef.value?.focus());
+};
+
+const saveEdit = () => {
+  let source = props.node.attrs.source ?? '';
+  const old = findMath(source)[0];
+  if (old && old.formula !== old.source) {
+    const offset = source.indexOf(old.formula);
+    source = source.slice(0, offset) + editFormula.value + source.slice(offset + old.formula.length);
+  } else source = '';
+  props.updateAttributes({ formula: editFormula.value, source });
+  isEditing.value = false;
+};
+
+const cancelEdit = () => {
+  editFormula.value = props.node.attrs.formula;
+  isEditing.value = false;
+};
+
+const handleKeydown = (e: KeyboardEvent) => {
+  if (e.key === "Escape") cancelEdit();
+  if ((e.key === "Enter" && (e.ctrlKey || e.metaKey)) || (e.key === "Enter" && !isBlock.value)) {
+    e.preventDefault();
+    saveEdit();
+  }
+};
+
+watch(() => props.node.attrs.formula, render);
+onMounted(render);
+</script>
+
+<template>
+  <NodeViewWrapper
+    :as="isBlock ? 'div' : 'span'"
+    class="katex-wrapper"
+    :class="{ 'katex-block': isBlock, 'katex-inline': !isBlock, selected: props.selected }"
+    :data-type="isBlock ? 'katex-block' : 'katex-inline'"
+    :data-formula="encodedFormula"
+    :data-math-source="encodeURIComponent(props.node.attrs.source ?? '')"
+    contenteditable="false"
+  >
+    <!-- View mode -->
+    <template v-if="!isEditing">
+      <span v-html="renderedHtml" class="katex-render" :class="{ 'katex-error': error }" :title="error ?? t.mathEdit" tabindex="0" role="button" :aria-label="t.mathEdit" @dblclick="startEdit" @keydown.enter.prevent="startEdit"></span>
+      <span class="katex-actions">
+        <button class="katex-btn" :title="t.mathEdit" @click="startEdit">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>
+        </button>
+        <button class="katex-btn danger" :title="t.mathDelete" @click="props.deleteNode">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+        </button>
+      </span>
+    </template>
+
+    <!-- Edit mode -->
+    <template v-else>
+      <span class="katex-editor">
+        <textarea
+          ref="textareaRef"
+          v-model="editFormula"
+          class="katex-textarea"
+          :aria-label="t.mathSource"
+          :rows="isBlock ? 4 : 1"
+          :placeholder="isBlock ? 'Enter LaTeX formula...\nE.g.: \\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}' : 'LaTeX formula'"
+          @keydown="handleKeydown"
+        ></textarea>
+        <span class="katex-editor-actions">
+          <button class="katex-save-btn" @click="saveEdit">{{ t.save }}</button>
+          <button class="katex-cancel-btn" @click="cancelEdit">{{ t.cancel }}</button>
+        </span>
+      </span>
+    </template>
+  </NodeViewWrapper>
+</template>
+
+<style scoped>
+.katex-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.katex-block {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  margin: 6px 0;
+  border-radius: 4px;
+  overflow-x: auto;
+  border: 1px solid transparent;
+  transition: border-color 0.15s;
+}
+
+.katex-block:hover {
+  border-color: var(--border-primary);
+}
+
+.katex-block.selected {
+  border-color: var(--primary);
+}
+
+.katex-inline {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  border-radius: 3px;
+  border: 1px solid transparent;
+}
+
+.katex-inline.selected {
+  border-color: var(--primary);
+}
+
+.katex-render {
+  cursor: default;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.katex-render :deep(.katex) {
+  font-size: 1.1em;
+}
+
+.katex-block .katex-render :deep(.katex) {
+  font-size: 1.3em;
+  max-width: 100%;
+  white-space: nowrap;
+}
+
+.katex-block .katex-render :deep(.katex-display) {
+  margin: 0;
+  max-width: 100%;
+  overflow: auto;
+  white-space: nowrap;
+}
+
+.katex-block .katex-render :deep(.katex-html) {
+  white-space: nowrap;
+}
+
+.katex-error {
+  color: var(--error-color, #ef4444);
+  font-size: 12px;
+  font-family: monospace;
+  padding: 2px 6px;
+  background: var(--error-bg, rgba(239, 68, 68, 0.1));
+  border-radius: 3px;
+}
+
+/* 浮動工具列：絕對定位，平時隱藏，hover 才顯示 */
+.katex-actions {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px 3px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  box-shadow: var(--shadow-dropdown, 0 2px 8px rgba(0,0,0,0.12));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+  z-index: 10;
+}
+
+.katex-wrapper:hover .katex-actions,
+.katex-wrapper:focus-within .katex-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Keep controls above inline formulas so they cannot intercept double-clicks. */
+.katex-inline .katex-actions {
+  top: auto;
+  bottom: 100%;
+  right: 0;
+}
+
+.katex-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  flex-shrink: 0;
+}
+
+.katex-btn:hover {
+  background: var(--hover-bg);
+  color: var(--text-primary);
+}
+
+.katex-btn.danger:hover {
+  background: var(--danger-bg, rgba(239, 68, 68, 0.1));
+  color: var(--danger, #ef4444);
+}
+
+.katex-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+}
+
+.katex-textarea {
+  width: 100%;
+  padding: 8px;
+  font-family: "Fira Code", "Consolas", monospace;
+  font-size: 13px;
+  border: 1px solid var(--border-primary);
+  border-radius: 4px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  resize: vertical;
+  min-height: 36px;
+}
+
+.katex-textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+}
+
+.katex-editor-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.katex-save-btn,
+.katex-cancel-btn {
+  padding: 3px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: none;
+  transition: background 0.15s;
+}
+
+.katex-save-btn {
+  background: var(--success, #22c55e);
+  color: white;
+}
+
+.katex-save-btn:hover {
+  background: var(--success-dark, #16a34a);
+}
+
+.katex-cancel-btn {
+  background: var(--text-muted);
+  color: white;
+}
+
+.katex-cancel-btn:hover {
+  background: var(--text-secondary);
+}
+</style>

--- a/src/components/ToolbarItemRenderer.vue
+++ b/src/components/ToolbarItemRenderer.vue
@@ -47,6 +47,7 @@ const emit = defineEmits<{
 }>();
 
 const {
+  insertMath,
   isActive,
   runCommand,
   characterCount,
@@ -88,7 +89,7 @@ const needsEditor = (id: string) => {
   const editorItems = [
     'undo', 'redo', 'heading-select', 'bold', 'italic', 'strikethrough', 'inline-code',
     'bullet-list', 'ordered-list', 'task-list', 'blockquote', 'code-block', 'horizontal-rule',
-    'page-break', 'link', 'image', 'table', 'mermaid', 'footnote',
+    'page-break', 'link', 'image', 'table', 'mermaid', 'footnote', 'math-inline', 'math-block',
   ];
   return editorItems.includes(id);
 };
@@ -397,6 +398,11 @@ const showLabel = (id: string) => {
       <button @click="deleteTable" class="dropdown-item danger" :disabled="!isActive('table')">{{ t.deleteTable }}</button>
     </div>
   </div>
+
+  <!-- Mermaid -->
+  <button v-else-if="itemId === 'math-inline' || itemId === 'math-block'" @mousedown.prevent @click="insertMath(itemId === 'math-block')" class="toolbar-btn" :aria-label="itemId === 'math-block' ? t.mathBlock : t.mathInline" v-tooltip="itemId === 'math-block' ? t.mathBlock : t.mathInline" :disabled="isDisabled(itemId)">
+    <span aria-hidden="true">{{ itemId === 'math-block' ? '∑' : '𝑥²' }}</span>
+  </button>
 
   <!-- Mermaid -->
   <button v-else-if="itemId === 'mermaid'" @click="insertMermaid" class="toolbar-btn mermaid-btn" :class="{ 'icon-only': !showLabel(itemId) }" v-tooltip="t.insertMermaid" :disabled="isDisabled(itemId)">

--- a/src/components/ai/AiSettingsTab.vue
+++ b/src/components/ai/AiSettingsTab.vue
@@ -136,7 +136,8 @@ function statusText(cli: CliKind): string {
   if (s.error?.toLowerCase().includes('binary') || s.error?.toLowerCase().includes('not found')) {
     return t.value.aiStatusBinaryMissing;
   }
-  return t.value.aiStatusAuthRequired;
+  if (s.error?.toLowerCase().includes('authentication')) return t.value.aiStatusAuthRequired;
+  return s.error || t.value.aiStatusUnknown;
 }
 
 function statusOk(cli: CliKind): boolean {
@@ -203,7 +204,7 @@ function placeholderFor(cli: CliKind): string {
     case 'mac':
       return `/opt/homebrew/bin/${cli}`;
     case 'win':
-      return `C:\\Users\\<you>\\AppData\\Roaming\\npm\\${cli}.cmd`;
+      return cli === 'codex' ? '%LOCALAPPDATA%\\OpenAI\\Codex\\bin\\codex.exe' : `C:\\Users\\<you>\\AppData\\Roaming\\npm\\${cli}.cmd`;
     default:
       return `/usr/local/bin/${cli}`;
   }
@@ -221,7 +222,9 @@ function searchedPaths(): string[] {
     case 'win':
       return [
         'PATH with PATHEXT (.exe / .cmd / .bat)',
-        'no extra fallbacks — install via npm / scoop / winget keeps PATH set',
+        '%LOCALAPPDATA%\\OpenAI\\Codex\\bin (including version folders)',
+        '%APPDATA%\\npm; %USERPROFILE%\\.local\\bin; scoop\\shims',
+        '%USERPROFILE%\\.cargo\\bin; .volta\\bin; .bun\\bin',
       ];
     default:
       return [
@@ -324,7 +327,7 @@ async function copyAudit() {
             </button>
           </div>
         </div>
-        <details class="ai-cli-path">
+        <details class="ai-cli-path" :open="!statusOk(cli)">
           <summary>{{ t.aiSettingsCliPathHeading }}</summary>
           <div class="ai-cli-path-row">
             <input
@@ -345,6 +348,7 @@ async function copyAudit() {
             </button>
           </div>
           <small class="ai-helper ai-helper--inline">{{ t.aiSettingsCliPathHelper }}</small>
+          <small v-if="cli === 'codex'" class="ai-helper ai-helper--inline">{{ t.aiCodexPathHint }}</small>
           <ul class="ai-cli-path-searched">
             <li v-for="(p, i) in searchedPaths()" :key="i">{{ p }}</li>
           </ul>

--- a/src/composables/useAi.ts
+++ b/src/composables/useAi.ts
@@ -362,8 +362,8 @@ export function useAi() {
       : opts.cli === 'openai'
         ? (settings.value.ai.openaiBaseUrl ?? '')
         : opts.cli === 'claude'
-          ? settings.value.ai.cliPathClaude
-          : settings.value.ai.cliPathCodex
+          ? (settings.value.ai.cliPathClaude || settings.value.ai.cliResolvedPathClaude)
+          : (settings.value.ai.cliPathCodex || settings.value.ai.cliResolvedPathCodex)
     ).trim();
     const req: AiSendRequest = {
       cli: opts.cli,

--- a/src/composables/useAiHealth.ts
+++ b/src/composables/useAiHealth.ts
@@ -78,12 +78,10 @@ export function useAiHealth() {
    *      (`cliResolvedPathClaude` / `cliResolvedPathCodex`).
    *   3. None — backend falls back to its full PATH + curated-dir scan.
    *
-   * The cached path is treated as if the user picked it manually: the backend
-   * returns it immediately when the file still exists, skipping the slow
-   * resolution path. If the cache is stale (binary moved), the override
-   * silently fails the file-exists check and we drop back to a full scan.
+   * Re-check bypasses automatic paths. If a cached installation disappears,
+   * check retries discovery without changing an explicit user selection.
    */
-  function overrideFor(cli: CliKind): string | null {
+  function overrideFor(cli: CliKind, force = false): string | null {
     // Ollama / OpenAI-compatible have no binary path — the "override" channel
     // carries their base URL instead.
     if (cli === 'ollama') return (settings.value.ai.ollamaBaseUrl ?? '').trim() || null;
@@ -91,6 +89,7 @@ export function useAiHealth() {
     const manualRaw = cli === 'claude' ? settings.value.ai.cliPathClaude : settings.value.ai.cliPathCodex;
     const manual = (manualRaw ?? '').trim();
     if (manual) return manual;
+    if (force) return null;
     const cachedRaw = cli === 'claude'
       ? settings.value.ai.cliResolvedPathClaude
       : settings.value.ai.cliResolvedPathCodex;
@@ -120,7 +119,15 @@ export function useAiHealth() {
     }
     loading.value[cli] = true;
     try {
-      const r = await aiCommands.healthCheck(cli, overrideFor(cli));
+      if (force && (cli === 'claude' || cli === 'codex')) forgetResolvedCache(cli);
+      let r = await aiCommands.healthCheck(cli, overrideFor(cli, force));
+      // A desktop update can remove the previously cached bundle. Only retry
+      // automatic paths; an explicit user selection must never be ignored.
+      const manual = cli === 'codex' ? settings.value.ai.cliPathCodex : settings.value.ai.cliPathClaude;
+      if (!force && (cli === 'claude' || cli === 'codex') && !manual?.trim() && !r.ok && !r.version && overrideFor(cli)) {
+        forgetResolvedCache(cli);
+        r = await aiCommands.healthCheck(cli, null);
+      }
       cache.value[cli] = r;
       lastCheckedAt.value[cli] = Date.now();
       if (cli === 'claude' || cli === 'codex') persistCliHealth();

--- a/src/composables/useDocxExport.ts
+++ b/src/composables/useDocxExport.ts
@@ -15,6 +15,7 @@ import { save } from '@tauri-apps/plugin-dialog';
 import { writeFile } from '@tauri-apps/plugin-fs';
 import { serializeEditorContent } from '../utils/documentSerializer';
 import { DOM_SELECTORS } from '../constants';
+import { decodeMath, mathMarkdown } from '../utils/math';
 
 type DocxItem = Paragraph | Table;
 
@@ -27,6 +28,9 @@ function buildTextRuns(node: Node): TextRun[] {
   if (node.nodeType !== Node.ELEMENT_NODE) return [];
 
   const el = node as Element;
+  if (el.matches('[data-type="katex-inline"], [data-type="katex-block"]')) {
+    return [new TextRun({ text: mathMarkdown(decodeMath(el.getAttribute('data-formula') ?? ''), decodeMath(el.getAttribute('data-math-source') ?? ''), el.getAttribute('data-type') === 'katex-block'), font: 'Cambria Math' })];
+  }
   const tag = el.tagName.toLowerCase();
   const childRuns: TextRun[] = [];
   for (const child of el.childNodes) {
@@ -153,6 +157,9 @@ const HEADING_LEVELS: Record<string, typeof HeadingLevel[keyof typeof HeadingLev
 };
 
 export function convertElementToDocxItems(el: Element): DocxItem[] {
+  if (el.matches('[data-type="katex-block"], [data-type="katex-inline"]')) {
+    return [new Paragraph({ children: buildTextRuns(el) })];
+  }
   const tag = el.tagName.toLowerCase();
 
   if (HEADING_LEVELS[tag]) {

--- a/src/composables/useMarpExport.ts
+++ b/src/composables/useMarpExport.ts
@@ -1,4 +1,5 @@
 import { Marp } from '@marp-team/marp-core';
+import { normalizeMathForMarp } from '../utils/math';
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeTextFile } from '@tauri-apps/plugin-fs';
 
@@ -49,7 +50,7 @@ export function splitSlides(markdown: string): string[] {
 
 export function renderDeck(markdown: string, marp?: MarpRenderer): MarpRenderResult {
   const renderer = marp ?? new Marp({ html: true });
-  const { html, css } = renderer.render(markdown);
+  const { html, css } = renderer.render(normalizeMathForMarp(markdown));
   return { html, css };
 }
 

--- a/src/composables/usePdfExport.ts
+++ b/src/composables/usePdfExport.ts
@@ -1,6 +1,8 @@
 import { invoke } from '@tauri-apps/api/core';
 import { serializeEditorContent } from '../utils/documentSerializer';
 import printCssRaw from '../styles/print.css?raw';
+import { mathPrintCss } from '../utils/math-print';
+import { renderMathNodes } from '../utils/math';
 import { DOM_SELECTORS } from '../constants';
 import { t } from '../i18n';
 
@@ -341,6 +343,11 @@ export function buildPrintDocument(
   meta: DocumentMeta = {},
 ): string {
   const m = resolveMargins(settings);
+  if (contentHtml.includes('data-type="katex-')) {
+    const root = new DOMParser().parseFromString(contentHtml, 'text/html').body;
+    renderMathNodes(root);
+    contentHtml = root.innerHTML;
+  }
   const bodyFont = getFontStack(settings.fontFamily);
   const headingFont = getFontStack(settings.headingFontFamily);
   const marginBoxes = buildPageMarginBoxes(settings, meta);
@@ -379,6 +386,7 @@ export function buildPrintDocument(
 }
 ${counterReset}
 ${printCss}
+${contentHtml.includes('katex') ? mathPrintCss : ''}
 ${watermarkCss}
 </style>
 </head>

--- a/src/composables/useToolbarActions.ts
+++ b/src/composables/useToolbarActions.ts
@@ -204,6 +204,11 @@ export function useToolbarActions() {
   };
 
   // Footnote — chain().focus() preserves selection after toolbar click steals focus
+  const insertMath = (display = false) => {
+    runCommand(e => display ? e.chain().focus().insertKatexBlock().run() : e.chain().focus().insertKatexInline().run());
+  };
+
+  // Footnote — chain().focus() preserves selection after toolbar click steals focus
   const insertFootnote = () => {
     runCommand((e) => (e.chain() as any).focus().insertFootnote().run());
   };
@@ -264,6 +269,7 @@ export function useToolbarActions() {
 
     // Mermaid
     insertMermaid,
+    insertMath,
 
     // Footnote
     insertFootnote,

--- a/src/data/toolbarItems.ts
+++ b/src/data/toolbarItems.ts
@@ -66,6 +66,10 @@ export const TOOLBAR_ITEMS: ToolbarItemDef[] = [
   { id: 'page-break', category: 'blocks', defaultZone: 'toolbar', defaultOrder: 530, needsEditor: true, labelKey: 'pageBreak' },
 
   // Links & Media
+  { id: 'math-inline', category: 'blocks', defaultZone: 'toolbar', defaultOrder: 540, needsEditor: true, labelKey: 'mathInline' },
+  { id: 'math-block', category: 'blocks', defaultZone: 'toolbar', defaultOrder: 550, needsEditor: true, labelKey: 'mathBlock' },
+
+  // Links & Media
   { id: 'link', category: 'links-media', defaultZone: 'toolbar', defaultOrder: 600, needsEditor: true, labelKey: 'link' },
   { id: 'image', category: 'links-media', defaultZone: 'toolbar', defaultOrder: 610, needsEditor: true, labelKey: 'image' },
 

--- a/src/extensions/KatexExtension.ts
+++ b/src/extensions/KatexExtension.ts
@@ -1,0 +1,146 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { VueNodeViewRenderer } from "@tiptap/vue-3";
+import KatexNode from "../components/KatexNode.vue";
+import { decodeMath } from '../utils/math';
+
+// Adapted from chinghssu/MerMarkEditorQ, commit b165dcf4 (MIT).
+const sourceAttribute = {
+  default: '',
+  parseHTML: (el: HTMLElement) => decodeMath(el.getAttribute('data-math-source') ?? ''),
+  renderHTML: (attrs: Record<string, unknown>) => ({ 'data-math-source': encodeURIComponent(String(attrs.source ?? '')) }),
+};
+
+export interface KatexOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    katexBlock: {
+      insertKatexBlock: (formula?: string) => ReturnType;
+    };
+    katexInline: {
+      insertKatexInline: (formula?: string) => ReturnType;
+    };
+  }
+}
+
+export const KatexBlockExtension = Node.create<KatexOptions>({
+  name: "katexBlock",
+
+  group: "block",
+
+  atom: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      source: sourceAttribute,
+      formula: {
+        default: "E = mc^2",
+        parseHTML: (element) => {
+          const f = element.getAttribute("data-formula");
+          return f ? decodeMath(f) : element.textContent || undefined;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.formula) return {};
+          return { "data-formula": encodeURIComponent(attributes.formula) };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="katex-block"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        "data-type": "katex-block",
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(KatexNode as any);
+  },
+
+  addCommands() {
+    return {
+      insertKatexBlock:
+        (formula?: string) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: { formula: formula || "E = mc^2" },
+          });
+        },
+    };
+  },
+});
+
+export const KatexInlineExtension = Node.create<KatexOptions>({
+  name: "katexInline",
+
+  group: "inline",
+
+  inline: true,
+
+  atom: true,
+
+  addOptions() {
+    return { HTMLAttributes: {} };
+  },
+
+  addAttributes() {
+    return {
+      source: sourceAttribute,
+      formula: {
+        default: "x",
+        parseHTML: (element) => {
+          const f = element.getAttribute("data-formula");
+          return f ? decodeMath(f) : element.textContent || undefined;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.formula) return {};
+          return { "data-formula": encodeURIComponent(attributes.formula) };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="katex-inline"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        "data-type": "katex-inline",
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return VueNodeViewRenderer(KatexNode as any);
+  },
+
+  addCommands() {
+    return {
+      insertKatexInline:
+        (formula?: string) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: { formula: formula || "x" },
+          });
+        },
+    };
+  },
+});

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -8,6 +8,12 @@ export type Locale = 'en' | 'pl' | 'zh-CN';
 export interface Translations {
   // App
   appName: string;
+  mathInline: string;
+  mathBlock: string;
+  mathEdit: string;
+  mathDelete: string;
+  mathSource: string;
+  aiCodexPathHint: string;
 
   // Toolbar - File operations
   new: string;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -2,6 +2,12 @@ import type { Translations } from '../index';
 
 const en: Translations = {
   appName: 'MerMark Editor',
+  mathInline: 'Inline formula',
+  mathBlock: 'Block formula',
+  mathEdit: 'Edit formula',
+  mathDelete: 'Delete formula',
+  mathSource: 'LaTeX source',
+  aiCodexPathHint: 'Select Codex CLI (.exe or .cmd), not the desktop app launcher. Desktop bundles are searched under %LOCALAPPDATA%\\OpenAI\\Codex\\bin. You can also paste a full path here.',
 
   // Toolbar - File operations
   new: 'New',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -2,6 +2,12 @@ import type { Translations } from '../index';
 
 const pl: Translations = {
   appName: 'MerMark Editor',
+  mathInline: 'Wzór w tekście',
+  mathBlock: 'Wzór blokowy',
+  mathEdit: 'Edytuj wzór',
+  mathDelete: 'Usuń wzór',
+  mathSource: 'Źródło LaTeX',
+  aiCodexPathHint: 'Wybierz Codex CLI (.exe lub .cmd), a nie program uruchamiający aplikację desktopową. Szukamy też w %LOCALAPPDATA%\\OpenAI\\Codex\\bin. Możesz wkleić pełną ścieżkę.',
 
   // Toolbar - File operations
   new: 'Nowy',

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1,6 +1,12 @@
 import type { Translations } from '../index';
 
 const zhCN: Translations = {
+  mathInline: '行内公式',
+  mathBlock: '块公式',
+  mathEdit: '编辑公式',
+  mathDelete: '删除公式',
+  mathSource: 'LaTeX 源码',
+  aiCodexPathHint: '请选择 Codex CLI（.exe 或 .cmd），而不是桌面应用启动器。也会搜索 %LOCALAPPDATA%\\OpenAI\\Codex\\bin。可以粘贴完整路径。',
   appName: 'MerMark 编辑器',
 
   // Toolbar - File operations

--- a/src/utils/documentSerializer.ts
+++ b/src/utils/documentSerializer.ts
@@ -1,3 +1,5 @@
+import { renderMathNodes } from './math';
+
 const STRIP_ATTRS = [
   'contenteditable',
   'data-node-view-wrapper',
@@ -423,6 +425,7 @@ export function linkifyFootnotes(root: HTMLElement): void {
  */
 export function serializeEditorContent(editorEl: HTMLElement): string {
   const clone = editorEl.cloneNode(true) as HTMLElement;
+  renderMathNodes(clone);
   inlineMermaidSvgs(clone);
   inlineTaskCheckboxes(clone);
   normalizeFootnoteSection(clone);

--- a/src/utils/lazy-markdown.ts
+++ b/src/utils/lazy-markdown.ts
@@ -1,4 +1,5 @@
 import { safeHtmlTagTokens } from './safe-html';
+import { findMath } from './math';
 
 export interface MarkdownChunk {
   markdown: string;
@@ -23,6 +24,9 @@ export function splitMarkdownForLazyPreview(markdown: string): MarkdownChunk[] {
   let fenceChar = '';
   let fenceLength = 0;
   let safeHtmlDepth = 0;
+  const math = findMath(markdown);
+  let mathIndex = 0;
+  let offset = 0;
 
   const push = (endExclusive: number) => {
     const chunkLines = lines.slice(start, endExclusive);
@@ -34,6 +38,9 @@ export function splitMarkdownForLazyPreview(markdown: string): MarkdownChunk[] {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     chars += line.length + 1;
+    offset += line.length + 1;
+    while (mathIndex < math.length && math[mathIndex].end < offset) mathIndex++;
+    const insideMath = mathIndex < math.length && math[mathIndex].start < offset && math[mathIndex].end >= offset;
 
     const fence = line.match(/^\s*(`{3,}|~{3,})/);
     if (fence) {
@@ -55,7 +62,7 @@ export function splitMarkdownForLazyPreview(markdown: string): MarkdownChunk[] {
       }
     }
 
-    if (fenceChar || safeHtmlDepth || chars < TARGET_CHUNK_CHARS) continue;
+    if (fenceChar || safeHtmlDepth || insideMath || chars < TARGET_CHUNK_CHARS) continue;
     const atBlockBoundary = line.trim() === '';
     if (atBlockBoundary || chars >= MAX_CHUNK_CHARS) push(i + 1);
   }

--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -23,6 +23,7 @@ export {
 } from './footnote-utils';
 
 import { decodeHtmlEntities, escapeHtml } from './html-entities';
+import { protectMath, protectMathHtml } from './math';
 import { convertInlineToMarkdown, extractMermaidCode, processHtmlLists } from './html-to-markdown';
 import {
   buildMermaidBlockFor,
@@ -103,6 +104,14 @@ export function htmlToMarkdown(
   let md = html.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 
   const protectedBlocks: string[] = [];
+  const mathSources: string[] = [];
+  let mathPrefix = 'MERMATHSAVE';
+  while (html.includes(mathPrefix)) mathPrefix += 'X';
+  md = protectMathHtml(md, source => {
+    const token = `${mathPrefix}${mathSources.length}TOKEN`;
+    mathSources.push(source);
+    return token;
+  });
 
   // Front matter badge -> restore raw `---\n…\n---` at the very top before the
   // generic <div> strip below would otherwise delete it.
@@ -333,7 +342,7 @@ export function htmlToMarkdown(
       const replaceEnd = lineEndPos === -1 ? md.length : lineEndPos;
       md = md.slice(0, lineStart) + indentedBlock + md.slice(replaceEnd);
     } else {
-      md = md.replace(placeholder, block);
+      md = md.replace(placeholder, () => block);
     }
   });
 
@@ -348,7 +357,7 @@ export function htmlToMarkdown(
     md += '\n\n' + footnoteSection.definitions;
   }
 
-  return md;
+  return md.replace(new RegExp(`${mathPrefix}(\\d+)TOKEN`, 'g'), (_, index) => mathSources[Number(index)] ?? '').replace(/^(?:[ \t]*\n)+/, '').trimEnd();
 }
 
 export function markdownToHtml(
@@ -400,6 +409,9 @@ export function markdownToHtmlWithMeta(
       return ph;
     });
   }
+
+  const math = protectMath(html);
+  html = math.text;
 
   // Extract page breaks and code blocks before escaping
   html = extractPageBreaks(html);
@@ -498,7 +510,7 @@ export function markdownToHtmlWithMeta(
   // Append footnotes section
   html += buildFootnoteSectionHtml(footnoteDefs);
 
-  return { html: (frontmatterHtml + html).trimEnd(), detectedMermaidFormatIds };
+  return { html: (frontmatterHtml + math.restore(html)).trimEnd(), detectedMermaidFormatIds };
 }
 
 function buildFrontmatterBadge(raw: string): string {

--- a/src/utils/markdown-to-html.ts
+++ b/src/utils/markdown-to-html.ts
@@ -395,12 +395,24 @@ export function extractCodeBlocks(
   // Generic fenced code blocks (\`\`\`lang ... \`\`\`). These run after mermaid
   // extraction so a remaining standard fence that happens to also be enabled
   // as a read format never reaches this pass.
-  html = html.replace(/```(\w*)\n?([\s\S]*?)```/gi, (_, lang, code) => {
+  const fences = /^( {0,3})(`{3,}|~{3,})([^\n]*)\n/gm;
+  let fencedHtml = '';
+  let fenceCursor = 0;
+  let fence: RegExpExecArray | null;
+  while ((fence = fences.exec(html))) {
+    const close = new RegExp(`^ {0,3}${fence[2][0]}{${fence[2].length},}[ \\t]*(?=\\n|$)`, 'gm');
+    close.lastIndex = fences.lastIndex;
+    const end = close.exec(html);
+    const code = html.slice(fences.lastIndex, end?.index ?? html.length);
+    const lang = /^[\w-]+/.exec(fence[3].trim())?.[0] ?? 'plaintext';
     const placeholder = `__CODE_BLOCK_${codeBlocks.length}__`;
     const escapedCode = escapeHtml(code);
-    codeBlocks.push(`<pre><code class="language-${lang || 'plaintext'}">${escapedCode}</code></pre>`);
-    return placeholder;
-  });
+    codeBlocks.push(`<pre><code class="language-${lang}">${escapedCode}</code></pre>`);
+    fencedHtml += html.slice(fenceCursor, fence.index) + fence[1] + placeholder;
+    fenceCursor = end ? end.index + end[0].length : html.length;
+    fences.lastIndex = fenceCursor;
+  }
+  html = fencedHtml + html.slice(fenceCursor);
 
   html = extractIndentedCodeBlocks(html, codeBlocks);
 

--- a/src/utils/math-print.ts
+++ b/src/utils/math-print.ts
@@ -1,0 +1,11 @@
+import css from 'katex/dist/katex.min.css?raw';
+
+// Inline fonts into print HTML: no CDN, file URL, or app origin is required.
+const fonts = import.meta.glob<string>('/node_modules/katex/dist/fonts/*.woff2', {
+  eager: true, query: '?inline', import: 'default',
+});
+export const mathPrintCss = css.replace(/src:[^;}]+/g, declaration => {
+  const name = /url\([^)]*?(KaTeX_[^/)]+\.woff2)\)/.exec(declaration)?.[1];
+  const url = name ? fonts[`/node_modules/katex/dist/fonts/${name}`] : undefined;
+  return url ? `src:url("${url}") format("woff2")` : declaration;
+}) + '\n.math-print-block { display:block; overflow-x:auto; break-inside:avoid; margin:.6em 0; } p:has(+ .math-print-block) { break-after:avoid; } .math-print-block .katex-display { margin:.25em 0; } .math-print-inline { display:inline; } .math-error { white-space:pre-wrap; color:#b91c1c; }';

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,197 @@
+import katex from 'katex';
+import { escapeHtml } from './html-entities';
+
+export interface MathSource {
+  start: number;
+  end: number;
+  formula: string;
+  source: string;
+  display: boolean;
+}
+
+const environments = /^(?:equation\*?|align\*?|alignat\*?|gather\*?|CD)$/;
+const escaped = (text: string, at: number): boolean => {
+  let count = 0;
+  while (at > 0 && text[--at] === '\\') count++;
+  return count % 2 === 1;
+};
+
+/** Scan source, never rendered HTML. Code, link destinations and escaped delimiters
+ * are opaque. Keep the complete source so a visual edit does not rewrite syntax. */
+export function findMath(text: string): MathSource[] {
+  const found: MathSource[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const lineStart = i === 0 || text[i - 1] === '\n';
+    if (lineStart) {
+      const fence = /^( {0,3})(`{3,}|~{3,})([^\n]*)\n/.exec(text.slice(i));
+      if (fence) {
+        const marker = fence[2];
+        const closeRe = new RegExp(`^ {0,3}${marker[0]}{${marker.length},}[ \\t]*(?=\\n|$)`, 'gm');
+        closeRe.lastIndex = i + fence[0].length;
+        const close = closeRe.exec(text);
+        const end = close ? close.index + close[0].length : text.length;
+        if (close && /^(math|latex|tex)$/i.test(fence[3].trim())) {
+          found.push({ start: i, end, formula: text.slice(i + fence[0].length, close.index).replace(/\n$/, ''), source: text.slice(i, end), display: true });
+        }
+        i = end;
+        continue;
+      }
+      // An indented code block cannot interrupt a paragraph.
+      if (/^( {4}|\t)/.test(text.slice(i)) && (i === 0 || (text[i - 1] === '\n' && text[i - 2] === '\n'))) {
+        const code = /^(?:(?: {4}|\t)[^\n]*(?:\n|$)|[ \t]*\n)+/.exec(text.slice(i));
+        if (code) { i += code[0].length; continue; }
+      }
+    }
+    if (text[i] === '`' && !escaped(text, i)) {
+      const run = /^`+/.exec(text.slice(i))![0];
+      const close = new RegExp(`(?<!\x60)\x60{${run.length}}(?!\x60)`, 'g');
+      close.lastIndex = i + run.length;
+      const match = close.exec(text);
+      i = match ? match.index + run.length : i + run.length;
+      continue;
+    }
+    if (text[i] === '<') {
+      const html = /^(?:<!--[\s\S]*?-->|<\/?[a-zA-Z][^>]*>|<https?:[^>]*>)/.exec(text.slice(i));
+      if (html) {
+        const tag = /^<([a-zA-Z][\w-]*)\b/.exec(html[0])?.[1];
+        // Raw HTML is handled by the safe-HTML extension; never put math tokens
+        // inside its encoded source attributes (or inside pre/code examples).
+        if (tag && !/^(img|br|hr|input|meta|link)$/i.test(tag)) {
+          const tags = new RegExp(`<(/?)${tag}\\b[^>]*>`, 'gi');
+          tags.lastIndex = i + html[0].length;
+          let depth = 1;
+          let match: RegExpExecArray | null;
+          while ((match = tags.exec(text))) {
+            depth += match[1] ? -1 : 1;
+            if (!depth) break;
+          }
+          if (match) { i = match.index + match[0].length; continue; }
+        }
+        i += html[0].length; continue;
+      }
+    }
+    if (text.startsWith('](', i)) {
+      let depth = 1;
+      i += 2;
+      while (i < text.length && depth) {
+        if (!escaped(text, i)) {
+          if (text[i] === '(') depth++;
+          if (text[i] === ')') depth--;
+        }
+        i++;
+      }
+      continue;
+    }
+    if (escaped(text, i)) { i++; continue; }
+    let open = '';
+    let close = '';
+    let display = false;
+    let environment = false;
+    if (text.startsWith('$`', i)) { open = '$`'; close = '`$'; }
+    else if (text.startsWith('$$', i)) { open = close = '$$'; display = true; }
+    else if (text[i] === '$' && text[i - 1] !== '$' && !/\s/.test(text[i + 1] ?? ' ') && text[i + 1]) { open = close = '$'; }
+    else if (text.startsWith('\\(', i)) { open = '\\('; close = '\\)'; }
+    else if (text.startsWith('\\[', i)) { open = '\\['; close = '\\]'; display = true; }
+    else if (text.startsWith('\\begin{', i)) {
+      const begin = /^\\begin\{([^}]+)\}/.exec(text.slice(i));
+      if (begin && environments.test(begin[1])) {
+        open = begin[0]; close = `\\end{${begin[1]}}`; display = true; environment = true;
+      }
+    }
+    if (!open) { i++; continue; }
+    let end = text.indexOf(close, i + open.length);
+    while (end >= 0 && (escaped(text, end) || (close === '$' && (text[end + 1] === '$' || /\s/.test(text[end - 1]))))) {
+      end = text.indexOf(close, end + close.length);
+    }
+    if (end < 0) { i += open.length; continue; }
+    const inner = text.slice(i + open.length, end);
+    // Avoid interpreting currency prose ($5 and $10) as an equation.
+    if ((!display && inner.includes('\n')) || !inner.trim() || (open === '$' && /\d/.test(text[end + 1] ?? ''))) {
+      i += open.length; continue;
+    }
+    end += close.length;
+    const source = text.slice(i, end);
+    found.push({ start: i, end, formula: environment ? source : inner, source, display });
+    i = end;
+  }
+  return found;
+}
+
+export function decodeMath(value: string): string {
+  try { return decodeURIComponent(value); } catch { return value; }
+}
+
+export function mathNodeHtml(math: Pick<MathSource, 'formula' | 'source' | 'display'>): string {
+  const tag = math.display ? 'div' : 'span';
+  const attr = (s: string) => escapeHtml(encodeURIComponent(s));
+  return `<${tag} data-type="katex-${math.display ? 'block' : 'inline'}" data-formula="${attr(math.formula)}" data-math-source="${attr(math.source)}"></${tag}>`;
+}
+
+export function protectMath(text: string): { text: string; restore: (html: string) => string } {
+  const matches = findMath(text);
+  let cursor = 0;
+  let result = '';
+  const replacements = new Map<string, string>();
+  // A document-specific prefix prevents authored text from colliding with tokens.
+  let prefix = 'MERMATH';
+  while (text.includes(prefix)) prefix += 'X';
+  for (const [index, math] of matches.entries()) {
+    const token = math.display ? `__${prefix}BLOCK${index}__` : `${prefix}INLINE${index}TOKEN`;
+    replacements.set(token, mathNodeHtml(math));
+    result += text.slice(cursor, math.start) + (math.display ? `\n${token}\n` : token);
+    cursor = math.end;
+  }
+  result += text.slice(cursor);
+  return { text: result, restore: html => html.replace(new RegExp(`__${prefix}BLOCK\\d+__|${prefix}INLINE\\d+TOKEN`, 'g'), token => replacements.get(token) ?? token) };
+}
+
+export function mathMarkdown(formula: string, source: string, display: boolean): string {
+  if (source) {
+    const parsed = findMath(source);
+    if (parsed.length === 1 && parsed[0].start === 0 && parsed[0].end === source.length && parsed[0].formula === formula && parsed[0].display === display) return source;
+  }
+  return display ? `$$\n${formula}\n$$` : `$${formula}$`;
+}
+
+export function protectMathHtml(html: string, protect: (source: string) => string): string {
+  if (!/data-type=["']katex-(?:block|inline)/.test(html)) return html;
+  const root = new DOMParser().parseFromString(html, 'text/html').body;
+  root.querySelectorAll('[data-type="katex-block"], [data-type="katex-inline"]').forEach(el => {
+    const display = el.getAttribute('data-type') === 'katex-block';
+    const md = mathMarkdown(decodeMath(el.getAttribute('data-formula') ?? ''), decodeMath(el.getAttribute('data-math-source') ?? ''), display);
+    el.replaceWith(document.createTextNode(protect(display ? `\n${md}\n` : md)));
+  });
+  return root.innerHTML;
+}
+
+/** Separate macros per equation: untrusted documents cannot redefine other formulas. */
+export function renderMath(formula: string, display: boolean): { html: string; error: string | null } {
+  try {
+    return { html: katex.renderToString(formula, { displayMode: display, output: 'htmlAndMathml', throwOnError: true, trust: false, maxExpand: 1000, maxSize: 20, strict: 'ignore' }), error: null };
+  } catch (e) {
+    const error = e instanceof Error ? e.message : 'Invalid LaTeX';
+    return { html: `<code class="math-error" title="${escapeHtml(error).replace(/"/g, '&quot;')}">${escapeHtml(formula)}</code>`, error };
+  }
+}
+
+export function renderMathNodes(root: HTMLElement): void {
+  root.querySelectorAll<HTMLElement>('[data-type="katex-block"], [data-type="katex-inline"]').forEach(el => {
+    const display = el.dataset.type === 'katex-block';
+    const formula = decodeMath(el.dataset.formula ?? '');
+    el.className = display ? 'math-print-block' : 'math-print-inline';
+    el.innerHTML = renderMath(formula, display).html;
+    el.removeAttribute('contenteditable');
+  });
+}
+
+/** Give Marp the same input syntaxes, while keeping its native math renderer. */
+export function normalizeMathForMarp(text: string): string {
+  const matches = findMath(text);
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    const source = m.display ? `\n$$\n${m.formula.trim()}\n$$\n` : `$${m.formula.trim()}$`;
+    text = text.slice(0, m.start) + source + text.slice(m.end);
+  }
+  return text;
+}

--- a/tests/e2e/math.test.ts
+++ b/tests/e2e/math.test.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { setupTauriMocks } from './helpers/tauri-mock';
+import { openCodeView, openVisualView } from './helpers/code-editor';
+
+const path = '/test/math-showcase.md';
+const showcase = readFileSync('docs/math-showcase.md', 'utf8');
+
+test('math showcase: edit, save, reopen, offline print and Marp', async ({ page, context }, testInfo) => {
+  test.setTimeout(90_000);
+  const fs = await setupTauriMocks(page, { initialFs: { [path]: showcase }, openFilePath: path });
+  await page.goto('/');
+  const formulas = page.locator('.ProseMirror .katex-wrapper');
+  await expect(formulas).toHaveCount(46);
+  await expect(page.locator('.ProseMirror .math-error')).toHaveCount(0);
+  await page.evaluate(() => document.fonts.ready);
+  await page.screenshot({ path: testInfo.outputPath('math-editor.png') });
+  // The editor suppresses dirty events for 300ms during initial hydration.
+  await page.waitForTimeout(400);
+
+  const first = formulas.first();
+  await first.locator('.katex-render').dblclick();
+  await first.getByRole('textbox').fill('E=mc^3');
+  await first.getByRole('textbox').press('Enter');
+  await expect(first).toHaveAttribute('data-formula', 'E%3Dmc%5E3');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => fs.getFs()[path]).toContain('$E=mc^3$');
+  await openCodeView(page);
+  await page.waitForTimeout(500); // allow the view's cursor/scroll restoration to finish
+  await openVisualView(page);
+  await expect(formulas).toHaveCount(46);
+  await page.reload();
+  await expect(formulas).toHaveCount(46);
+  await expect(formulas.first()).toHaveAttribute('data-formula', 'E%3Dmc%5E3');
+  await formulas.first().locator('.katex-render').dblclick();
+  await formulas.first().getByRole('textbox').fill('E=mc^2');
+  await formulas.first().getByRole('textbox').press('Enter');
+
+  const output = await page.evaluate(async () => {
+    const serializerPath = '/src/utils/documentSerializer.ts';
+    const pdfPath = '/src/composables/usePdfExport.ts';
+    const marpPath = '/src/composables/useMarpExport.ts';
+    const { serializeEditorContent } = await import(/* @vite-ignore */ serializerPath);
+    const { buildPrintDocument, PDF_SETTINGS_DEFAULTS } = await import(/* @vite-ignore */ pdfPath);
+    const { renderDeck, buildStandaloneHtml } = await import(/* @vite-ignore */ marpPath);
+    const root = document.querySelector('.ProseMirror') as HTMLElement;
+    return {
+      print: buildPrintDocument(serializeEditorContent(root), PDF_SETTINGS_DEFAULTS, (await import(/* @vite-ignore */ '/src/styles/print.css?raw')).default, { title: 'Matematyka w MerMark Editor' }),
+      deck: buildStandaloneHtml(renderDeck('---\nmarp: true\n---\n# Math\n\n' + String.raw`\(U=RI\)` + '\n\n```math\nP=UI\n```')),
+    };
+  });
+  expect(output.print).toContain('data:font/woff2;base64,');
+  expect(output.print).not.toContain('katex-actions');
+  const printPage = await context.newPage();
+  const external: string[] = [];
+  printPage.on('request', request => { if (/^https?:/.test(request.url())) external.push(request.url()); });
+  await context.setOffline(true);
+  await printPage.setContent(output.print);
+  await printPage.evaluate(() => document.fonts.ready);
+  await expect(printPage.locator('.katex')).toHaveCount(46);
+  expect(await printPage.evaluate(() => document.fonts.check('16px KaTeX_Main'))).toBe(true);
+  expect(external).toEqual([]);
+  await printPage.screenshot({ path: testInfo.outputPath('math-print.png'), fullPage: true });
+  await printPage.pdf({ path: testInfo.outputPath('math-showcase.pdf'), format: 'A4', printBackground: true, preferCSSPageSize: true });
+  await printPage.setContent(output.deck);
+  expect(await printPage.locator('mjx-container').count()).toBe(2);
+  await printPage.screenshot({ path: testInfo.outputPath('math-marp.png') });
+});
+
+test('invalid formula is editable; toolbar inserts inline and block formulas', async ({ page }) => {
+  await setupTauriMocks(page, { initialFs: { [path]: '$\\notACommand{x}$' }, openFilePath: path });
+  await page.goto('/');
+  const formula = page.locator('.katex-wrapper').first();
+  await expect(formula.locator('.math-error')).toBeVisible();
+  await formula.locator('.katex-render').focus();
+  await page.keyboard.press('Enter');
+  await formula.getByRole('textbox').fill('x^2');
+  await formula.getByRole('textbox').press('Enter');
+  await expect(page.locator('.math-error')).toHaveCount(0);
+  await page.getByRole('button', { name: 'Inline formula', exact: true }).click();
+  await expect(page.locator('.katex-inline')).toHaveCount(2);
+  await page.getByRole('button', { name: 'Block formula', exact: true }).click();
+  await expect(page.locator('.katex-block')).toHaveCount(1);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     globals: true,
+    css: { include: /katex/ },
     environment: 'jsdom',
     include: ['src/**/*.{test,spec}.{js,ts}'],
     setupFiles: ['./vitest.setup.ts'],


### PR DESCRIPTION
## Summary

Add editable math formulas to Markdown documents and fix Windows Codex CLI discovery so users can connect without accidentally selecting the desktop launcher.

- Support inline and display formulas, common LaTeX delimiters, math/latex/tex fences and equation environments, with source-preserving editing and toolbar actions.
- Render formulas in offline PDF exports and normalize alternate syntax for Marp slides. DOCX keeps LaTeX source as text; native Word equations are outside this change.
- Search desktop-managed Codex installations, npm and common user installation directories; validate CLI candidates, reject launchers, and respect explicit paths. Make manual selection easier to find after connection errors.
- Include a 46-formula showcase, implementation/validation notes, converter tests and browser coverage.

Math nodes are adapted from chinghssu/MerMarkEditorQ commit b165dcf4fa5efbe04ac8d03adf0fc3d1f3f54393 (MIT); unrelated fork changes are excluded.

## Validation

- Frontend: 87 test files, 1,182 tests passed.
- Rust AI tests: 172 passed.
- Production build passed.
- Selected Playwright regression suite: 15 passed; math suite rechecked after final adjustments.
- Offline PDF generated and all four pages visually reviewed.

Browser tests mock Tauri IPC; a packaged desktop installation and paid model calls were not tested. Math supports KaTeX syntax, not full LaTeX/TikZ.

## Release preparation

Prepare v0.7.3 separately after opening this PR. Do not merge until the version bump and completed release notes have been reviewed and included; merging to master triggers release publication.

Closes #139
Closes #143
